### PR TITLE
Fix multifield req

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Add this dependency to your project's build file:
 
 - Java11+
 ```groovy
-implementation 'com.fullcontact.client:java11:2.2.1'
+implementation 'com.fullcontact.client:java11:2.3.0'
 ```
 - Java8+
 ```groovy
-implementation 'com.fullcontact.client:java8:2.2.1'
+implementation 'com.fullcontact.client:java8:2.3.0'
 ```
 
 ### Maven users
@@ -29,7 +29,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.fullcontact.client</groupId>
   <artifactId>java11</artifactId>
-  <version>2.2.1</version>
+  <version>2.3.0</version>
 </dependency>
 ```
 - Java8+
@@ -37,7 +37,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.fullcontact.client</groupId>
   <artifactId>java8</artifactId>
-  <version>2.2.1</version>
+  <version>2.3.0</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ def getRepositoryPassword() {
 subprojects {
 
     dependencies {
-        compileOnly 'org.projectlombok:lombok:1.18.10'
-        annotationProcessor 'org.projectlombok:lombok:1.18.10'
+        compileOnly 'org.projectlombok:lombok:1.18.18'
+        annotationProcessor 'org.projectlombok:lombok:1.18.18'
         testCompile group: 'junit', name: 'junit', version: '4.12'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 group 'com.fullcontact.client'
-version '2.2.1'
+version '2.3.0'
 
 
 allprojects {

--- a/java-common-artifacts/build.gradle
+++ b/java-common-artifacts/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.fullcontact.client'
-version '2.2.1'
+version '2.3.0'
 
 sourceCompatibility = 1.8
 

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/FCConstants.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/FCConstants.java
@@ -7,7 +7,7 @@ public class FCConstants {
   public static final String API_BASE_DEFAULT = "https://api.fullcontact.com/v3/";
   public static final String API_BASE_V2 = "https://api.fullcontact.com/v2/";
 
-  public static final String VERSION = "2.2.1";
+  public static final String VERSION = "2.3.0";
 
   // User Agent
   public static final String USER_AGENT_Java8 = "FullContact_Java8_Client_V" + VERSION;

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Location.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Location.java
@@ -4,6 +4,7 @@ import lombok.*;
 
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
+@EqualsAndHashCode
 @Builder
 @Getter
 public class Location {

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/PersonName.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/PersonName.java
@@ -4,6 +4,7 @@ import lombok.*;
 
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
+@EqualsAndHashCode
 @Builder
 @Getter
 public class PersonName {

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Profile.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Profile.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 @Getter
 @Builder
+@EqualsAndHashCode
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
 public class Profile {

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/AudienceRequest.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/AudienceRequest.java
@@ -3,6 +3,7 @@ package com.fullcontact.apilib.models.Request;
 import com.fullcontact.apilib.FullContactException;
 import com.fullcontact.apilib.models.Tag;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Singular;
 
@@ -10,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 
 @Builder(toBuilder = true)
+@EqualsAndHashCode
 @Getter
 public class AudienceRequest {
   private String webhookUrl;

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/CompanyRequest.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/CompanyRequest.java
@@ -3,11 +3,13 @@ package com.fullcontact.apilib.models.Request;
 import com.fullcontact.apilib.FullContactException;
 import com.fullcontact.apilib.models.enums.Sort;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.With;
 
 /** Class to create requests for Company Enrich and Company Search */
 @Builder(toBuilder = true)
+@EqualsAndHashCode
 @Getter
 public class CompanyRequest {
   @With private String domain, companyName, webhookUrl, location, locality, region, country;

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/MultifieldRequest.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/MultifieldRequest.java
@@ -48,33 +48,46 @@ public class MultifieldRequest {
     return value != null && !value.trim().isEmpty();
   }
 
+  public boolean isQueryable() {
+    return (!this.emails.isEmpty()
+        || !this.phones.isEmpty()
+        || !this.profiles.isEmpty()
+        || !this.maids.isEmpty()
+        || isPopulated(this.recordId)
+        || isPopulated(this.personId)
+        || isPopulated(this.partnerId)
+        || isPopulated(this.li_nonid));
+  }
+
   /**
-   * Check for minimum combinations of 'name' and 'location', if present
+   * Check for minimum combinations of 'name' and 'location', if no other queryable field is present
    *
    * @throws FullContactException if 'name' and 'location' combination is not valid
    */
   public void validate() throws FullContactException {
-    if (location == null && name == null) {
-      return;
-    } else if (location != null && name != null) {
-      // Validating Location fields
-      if (isPopulated(location.getAddressLine1())
-          && ((isPopulated(location.getCity())
-                  && (isPopulated(location.getRegion()) || isPopulated(location.getRegionCode())))
-              || (isPopulated(location.getPostalCode())))) {
-        // Validating Name fields
-        if ((isPopulated(name.getFull()))
-            || (isPopulated(name.getGiven()) && isPopulated(name.getFamily()))) {
-          return;
+    if (!this.isQueryable()) {
+      if (location == null && name == null) {
+        return;
+      } else if (location != null && name != null) {
+        // Validating Location fields
+        if (isPopulated(location.getAddressLine1())
+            && ((isPopulated(location.getCity())
+                    && (isPopulated(location.getRegion()) || isPopulated(location.getRegionCode())))
+                || (isPopulated(location.getPostalCode())))) {
+          // Validating Name fields
+          if ((isPopulated(name.getFull()))
+              || (isPopulated(name.getGiven()) && isPopulated(name.getFamily()))) {
+            return;
+          } else {
+            throw new FullContactException("Name data requires full name or given and family name");
+          }
         } else {
-          throw new FullContactException("Name data requires full name or given and family name");
+          throw new FullContactException(
+              "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
         }
-      } else {
-        throw new FullContactException(
-            "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
       }
+      throw new FullContactException(
+          "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values");
     }
-    throw new FullContactException(
-        "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values");
   }
 }

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/MultifieldRequest.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/MultifieldRequest.java
@@ -7,11 +7,10 @@ import com.fullcontact.apilib.models.Profile;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
-import java.util.Collections;
 import java.util.List;
 
 @Getter
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 @AllArgsConstructor
 @EqualsAndHashCode
 public class MultifieldRequest {
@@ -20,23 +19,6 @@ public class MultifieldRequest {
   private String recordId, personId, partnerId, li_nonid;
   @Singular private List<String> phones, emails, maids;
   @Singular private List<Profile> profiles;
-
-  protected MultifieldRequest(MultifieldRequestBuilder<?, ?> b) {
-    this.name = b.name;
-    this.location = b.location;
-    this.recordId = b.recordId;
-    this.personId = b.personId;
-    this.partnerId = b.partnerId;
-    this.li_nonid = b.li_nonid;
-    this.phones =
-        b.phones != null ? Collections.unmodifiableList(b.phones) : Collections.emptyList();
-    this.emails =
-        b.emails != null ? Collections.unmodifiableList(b.emails) : Collections.emptyList();
-    this.maids =
-        b.maids != null ? Collections.unmodifiableList((b.maids)) : Collections.emptyList();
-    this.profiles =
-        b.profiles != null ? Collections.unmodifiableList(b.profiles) : Collections.emptyList();
-  }
 
   /**
    * Check the String if it is null or empty

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/MultifieldRequest.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/MultifieldRequest.java
@@ -4,10 +4,7 @@ import com.fullcontact.apilib.FullContactException;
 import com.fullcontact.apilib.models.Location;
 import com.fullcontact.apilib.models.PersonName;
 import com.fullcontact.apilib.models.Profile;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Singular;
-import lombok.With;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.util.Collections;
@@ -16,6 +13,7 @@ import java.util.List;
 @Getter
 @SuperBuilder
 @AllArgsConstructor
+@EqualsAndHashCode
 public class MultifieldRequest {
   @With private PersonName name;
   @With private Location location;
@@ -38,8 +36,6 @@ public class MultifieldRequest {
         b.maids != null ? Collections.unmodifiableList((b.maids)) : Collections.emptyList();
     this.profiles =
         b.profiles != null ? Collections.unmodifiableList(b.profiles) : Collections.emptyList();
-    System.out.println(this.emails);
-    //    this.validate();
   }
 
   /**

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/MultifieldRequest.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/MultifieldRequest.java
@@ -1,0 +1,84 @@
+package com.fullcontact.apilib.models.Request;
+
+import com.fullcontact.apilib.FullContactException;
+import com.fullcontact.apilib.models.Location;
+import com.fullcontact.apilib.models.PersonName;
+import com.fullcontact.apilib.models.Profile;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.With;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@AllArgsConstructor
+public class MultifieldRequest {
+  @With private PersonName name;
+  @With private Location location;
+  private String recordId, personId, partnerId, li_nonid;
+  @Singular private List<String> phones, emails, maids;
+  @Singular private List<Profile> profiles;
+
+  protected MultifieldRequest(MultifieldRequestBuilder<?, ?> b) {
+    this.name = b.name;
+    this.location = b.location;
+    this.recordId = b.recordId;
+    this.personId = b.personId;
+    this.partnerId = b.partnerId;
+    this.li_nonid = b.li_nonid;
+    this.phones =
+        b.phones != null ? Collections.unmodifiableList(b.phones) : Collections.emptyList();
+    this.emails =
+        b.emails != null ? Collections.unmodifiableList(b.emails) : Collections.emptyList();
+    this.maids =
+        b.maids != null ? Collections.unmodifiableList((b.maids)) : Collections.emptyList();
+    this.profiles =
+        b.profiles != null ? Collections.unmodifiableList(b.profiles) : Collections.emptyList();
+    System.out.println(this.emails);
+    //    this.validate();
+  }
+
+  /**
+   * Check the String if it is null or empty
+   *
+   * @param value String value to check for non blank values
+   * @return true if String is valid
+   */
+  protected static boolean isPopulated(String value) {
+    return value != null && !value.trim().isEmpty();
+  }
+
+  /**
+   * Check for minimum combinations of 'name' and 'location', if present
+   *
+   * @throws FullContactException if 'name' and 'location' combination is not valid
+   */
+  public void validate() throws FullContactException {
+    if (location == null && name == null) {
+      return;
+    } else if (location != null && name != null) {
+      // Validating Location fields
+      if (isPopulated(location.getAddressLine1())
+          && ((isPopulated(location.getCity())
+                  && (isPopulated(location.getRegion()) || isPopulated(location.getRegionCode())))
+              || (isPopulated(location.getPostalCode())))) {
+        // Validating Name fields
+        if ((isPopulated(name.getFull()))
+            || (isPopulated(name.getGiven()) && isPopulated(name.getFamily()))) {
+          return;
+        } else {
+          throw new FullContactException("Name data requires full name or given and family name");
+        }
+      } else {
+        throw new FullContactException(
+            "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+      }
+    }
+    throw new FullContactException(
+        "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values");
+  }
+}

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/PersonRequest.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/PersonRequest.java
@@ -1,6 +1,7 @@
 package com.fullcontact.apilib.models.Request;
 
 import com.fullcontact.apilib.models.enums.Confidence;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -10,19 +11,10 @@ import java.util.List;
 /** Class to create request for Person Enrich */
 @Getter
 @EqualsAndHashCode(callSuper = true)
-@SuperBuilder(builderMethodName = "personRequestBuilder")
+@SuperBuilder(builderMethodName = "personRequestBuilder", toBuilder = true)
 public class PersonRequest extends MultifieldRequest {
   private String webhookUrl;
   private Confidence confidence;
-  private boolean infer;
+  @Builder.Default private boolean infer = true;
   private List<String> dataFilter;
-
-  protected PersonRequest(PersonRequestBuilder<?, ?> b) {
-    super(b);
-    this.infer = true;
-    this.webhookUrl = b.webhookUrl;
-    this.confidence = b.confidence;
-    this.infer = b.infer;
-    this.dataFilter = b.dataFilter;
-  }
 }

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/PersonRequest.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/PersonRequest.java
@@ -1,7 +1,7 @@
 package com.fullcontact.apilib.models.Request;
 
-import com.fullcontact.apilib.FullContactException;
 import com.fullcontact.apilib.models.enums.Confidence;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
@@ -9,6 +9,7 @@ import java.util.List;
 
 /** Class to create request for Person Enrich */
 @Getter
+@EqualsAndHashCode(callSuper = true)
 @SuperBuilder(builderMethodName = "personRequestBuilder")
 public class PersonRequest extends MultifieldRequest {
   private String webhookUrl;

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/PersonRequest.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/PersonRequest.java
@@ -1,105 +1,27 @@
 package com.fullcontact.apilib.models.Request;
 
 import com.fullcontact.apilib.FullContactException;
-import com.fullcontact.apilib.models.Location;
-import com.fullcontact.apilib.models.PersonName;
-import com.fullcontact.apilib.models.Profile;
 import com.fullcontact.apilib.models.enums.Confidence;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.Singular;
-import lombok.With;
+import lombok.experimental.SuperBuilder;
 
-import java.util.Collections;
 import java.util.List;
 
 /** Class to create request for Person Enrich */
-@Builder(toBuilder = true)
 @Getter
-public class PersonRequest {
-  @With private PersonName name;
-  @With private Location location;
-  private String webhookUrl, recordId, personId, partnerId, li_nonid;
+@SuperBuilder(builderMethodName = "personRequestBuilder")
+public class PersonRequest extends MultifieldRequest {
+  private String webhookUrl;
   private Confidence confidence;
   private boolean infer;
-  @Singular private List<String> phones, emails, maids;
-  @Singular private List<Profile> profiles;
   private List<String> dataFilter;
 
-  public static class PersonRequestBuilder {
-    private boolean infer = true;
-
-    public PersonRequest build() throws FullContactException {
-      List<String> phones =
-          this.phones != null ? Collections.unmodifiableList(this.phones) : Collections.emptyList();
-      List<String> emails =
-          this.emails != null ? Collections.unmodifiableList(this.emails) : Collections.emptyList();
-      List<String> dataFilter =
-          this.dataFilter != null
-              ? Collections.unmodifiableList((this.dataFilter))
-              : Collections.emptyList();
-      List<String> maids =
-          this.maids != null ? Collections.unmodifiableList((this.maids)) : Collections.emptyList();
-      List<Profile> profiles =
-          this.profiles != null
-              ? Collections.unmodifiableList(this.profiles)
-              : Collections.emptyList();
-      this.validate();
-      return new PersonRequest(
-          name,
-          location,
-          webhookUrl,
-          recordId,
-          personId,
-          partnerId,
-          li_nonid,
-          confidence,
-          infer,
-          phones,
-          emails,
-          maids,
-          profiles,
-          dataFilter);
-    }
-
-    /**
-     * Check the String if it is null or empty
-     *
-     * @param value String value to check for non blank values
-     * @return true if String is valid
-     */
-    protected static boolean isPopulated(String value) {
-      return value != null && !value.trim().isEmpty();
-    }
-
-    /**
-     * Check for minimum combinations of 'name' and 'location', if present
-     *
-     * @throws FullContactException if 'name' and 'location' combination is not valid
-     */
-    public void validate() throws FullContactException {
-      if (location == null && name == null) {
-        return;
-      } else if (location != null && name != null) {
-        // Validating Location fields
-        if (isPopulated(location.getAddressLine1())
-            && ((isPopulated(location.getCity())
-                    && (isPopulated(location.getRegion()) || isPopulated(location.getRegionCode())))
-                || (isPopulated(location.getPostalCode())))) {
-          // Validating Name fields
-          if ((isPopulated(name.getFull()))
-              || (isPopulated(name.getGiven()) && isPopulated(name.getFamily()))) {
-            return;
-          } else {
-            throw new FullContactException("Name data requires full name or given and family name");
-          }
-        } else {
-          throw new FullContactException(
-              "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
-        }
-      }
-      throw new FullContactException(
-          "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values");
-    }
+  protected PersonRequest(PersonRequestBuilder<?, ?> b) {
+    super(b);
+    this.infer = true;
+    this.webhookUrl = b.webhookUrl;
+    this.confidence = b.confidence;
+    this.infer = b.infer;
+    this.dataFilter = b.dataFilter;
   }
 }

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/ResolveRequest.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/ResolveRequest.java
@@ -22,6 +22,7 @@ public class ResolveRequest extends MultifieldRequest {
    * @throws FullContactException if validation fails
    */
   public void validateForIdentityMap() throws FullContactException {
+    this.validate();
     if (this.getPersonId() != null) {
       throw new FullContactException("Invalid map request, person id must be empty");
     }
@@ -49,6 +50,7 @@ public class ResolveRequest extends MultifieldRequest {
    * @throws FullContactException if validation fails
    */
   public void validateForIdentityResolve() throws FullContactException {
+    this.validate();
     if (isPopulated(this.getRecordId()) && isPopulated(this.getPersonId())) {
       throw new FullContactException(
           "Both record id and person id are populated, please select one");
@@ -61,6 +63,7 @@ public class ResolveRequest extends MultifieldRequest {
    * @throws FullContactException if validation fails
    */
   public void validateForIdentityDelete() throws FullContactException {
+    this.validate();
     if (!isPopulated(this.getRecordId())) {
       throw new FullContactException("recordId param must be specified");
     }

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/ResolveRequest.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/ResolveRequest.java
@@ -1,26 +1,18 @@
 package com.fullcontact.apilib.models.Request;
 
 import com.fullcontact.apilib.FullContactException;
-import com.fullcontact.apilib.models.Location;
-import com.fullcontact.apilib.models.PersonName;
-import com.fullcontact.apilib.models.Profile;
 import com.fullcontact.apilib.models.Tag;
-import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Singular;
-import lombok.With;
+import lombok.experimental.SuperBuilder;
 
-import java.util.Collections;
 import java.util.List;
 /** Class to create request for Resolve */
-@Builder(toBuilder = true)
 @Getter
-public class ResolveRequest {
-  @With private PersonName name;
-  @With private Location location;
-  private String recordId, personId, partnerId, li_nonid;
-  @Singular private List<String> phones, emails, maids;
-  @Singular private List<Profile> profiles;
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder(builderMethodName = "resolveRequestBuilder")
+public class ResolveRequest extends MultifieldRequest {
   @Singular private List<Tag> tags;
 
   /**
@@ -30,13 +22,13 @@ public class ResolveRequest {
    * @throws FullContactException if validation fails
    */
   public void validateForIdentityMap() throws FullContactException {
-    if (this.personId != null) {
+    if (this.getPersonId() != null) {
       throw new FullContactException("Invalid map request, person id must be empty");
     }
-    if ((this.name != null && this.location != null)
-        || !this.emails.isEmpty()
-        || !this.phones.isEmpty()
-        || !this.profiles.isEmpty()) {
+    if ((this.getName() != null && this.getLocation() != null)
+        || !this.getEmails().isEmpty()
+        || !this.getPhones().isEmpty()
+        || !this.getProfiles().isEmpty()) {
     } else {
       throw new FullContactException(
           "Invalid map request, Any of Email, Phone, SocialProfile, Name and Location must be present");
@@ -57,7 +49,7 @@ public class ResolveRequest {
    * @throws FullContactException if validation fails
    */
   public void validateForIdentityResolve() throws FullContactException {
-    if (isPopulated(this.recordId) && isPopulated(this.personId)) {
+    if (isPopulated(this.getRecordId()) && isPopulated(this.getPersonId())) {
       throw new FullContactException(
           "Both record id and person id are populated, please select one");
     }
@@ -69,70 +61,8 @@ public class ResolveRequest {
    * @throws FullContactException if validation fails
    */
   public void validateForIdentityDelete() throws FullContactException {
-    if (!isPopulated(this.recordId)) {
+    if (!isPopulated(this.getRecordId())) {
       throw new FullContactException("recordId param must be specified");
-    }
-  }
-
-  /**
-   * Check the String if it is null or empty
-   *
-   * @param value String value to check for non blank values
-   * @return true if String is valid
-   */
-  protected static boolean isPopulated(String value) {
-    return value != null && !value.trim().isEmpty();
-  }
-
-  public static class ResolveRequestBuilder {
-
-    public ResolveRequest build() throws FullContactException {
-      List<String> phones =
-          this.phones != null ? Collections.unmodifiableList(this.phones) : Collections.emptyList();
-      List<String> emails =
-          this.emails != null ? Collections.unmodifiableList(this.emails) : Collections.emptyList();
-      List<String> maids =
-          this.maids != null ? Collections.unmodifiableList((this.maids)) : Collections.emptyList();
-      List<Profile> profiles =
-          this.profiles != null
-              ? Collections.unmodifiableList(this.profiles)
-              : Collections.emptyList();
-      List<Tag> tags =
-          this.tags != null ? Collections.unmodifiableList((this.tags)) : Collections.emptyList();
-      this.validate();
-      return new ResolveRequest(
-          name, location, recordId, personId, partnerId, li_nonid, phones, emails, maids, profiles,
-          tags);
-    }
-
-    /**
-     * Check for minimum combinations of 'name' and 'location', if present
-     *
-     * @throws FullContactException if 'name' and 'location' combination is not valid
-     */
-    public void validate() throws FullContactException {
-      if (location == null && name == null) {
-        return;
-      } else if (location != null && name != null) {
-        // Validating Location fields
-        if (isPopulated(location.getAddressLine1())
-            && ((isPopulated(location.getCity())
-                    && (isPopulated(location.getRegion()) || isPopulated(location.getRegionCode())))
-                || (isPopulated(location.getPostalCode())))) {
-          // Validating Name fields
-          if ((isPopulated(name.getFull()))
-              || (isPopulated(name.getGiven()) && isPopulated(name.getFamily()))) {
-            return;
-          } else {
-            throw new FullContactException("Name data requires full name or given and family name");
-          }
-        } else {
-          throw new FullContactException(
-              "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
-        }
-      }
-      throw new FullContactException(
-          "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values");
     }
   }
 }

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/TagsRequest.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Request/TagsRequest.java
@@ -3,12 +3,14 @@ package com.fullcontact.apilib.models.Request;
 import com.fullcontact.apilib.FullContactException;
 import com.fullcontact.apilib.models.Tag;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Singular;
 
 import java.util.Collections;
 import java.util.List;
 
+@EqualsAndHashCode
 @Builder(toBuilder = true)
 @Getter
 public class TagsRequest {

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/AudienceResponse.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/AudienceResponse.java
@@ -10,12 +10,9 @@ import java.io.IOException;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class AudienceResponse {
+public class AudienceResponse extends FCResponse {
   private String requestId;
   private byte[] audienceBytes;
-  public boolean isSuccessful;
-  public int statusCode;
-  public String message;
 
   public AudienceResponse(byte[] audienceBytes) {
     this.audienceBytes = audienceBytes;

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/CompanyResponse.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/CompanyResponse.java
@@ -8,12 +8,9 @@ import java.util.List;
 @ToString
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
-public class CompanyResponse {
+public class CompanyResponse extends FCResponse {
   private String name, location, twitter, linkedin, bio, logo, website, locale, category, updated;
   private int founded, employees;
   private CompanyDetails details;
   private List<DataAddOns> dataAddOns;
-  public boolean isSuccessful;
-  public int statusCode;
-  public String message;
 }

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/CompanySearchResponseList.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/CompanySearchResponseList.java
@@ -10,9 +10,6 @@ import java.util.List;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
-public class CompanySearchResponseList {
+public class CompanySearchResponseList extends FCResponse {
   public List<CompanySearchResponse> companySearchResponses;
-  public String message;
-  public int statusCode;
-  public boolean isSuccessful;
 }

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/EmailVerificationResponse.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/EmailVerificationResponse.java
@@ -8,12 +8,9 @@ import java.util.Map;
 @ToString
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
-public class EmailVerificationResponse {
+public class EmailVerificationResponse extends FCResponse {
   private int status;
   private String requestId;
   private String[] unknownEmails, failedEmails;
   private Map<String, EmailProperties> emails;
-  public String message;
-  public int statusCode;
-  public boolean isSuccessful;
 }

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/FCResponse.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/FCResponse.java
@@ -1,0 +1,15 @@
+package com.fullcontact.apilib.models.Response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@NoArgsConstructor
+@Getter
+public class FCResponse {
+  public boolean isSuccessful;
+  public int statusCode;
+  public String message;
+}

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/PersonResponse.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/PersonResponse.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 @ToString
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
-public class PersonResponse {
+public class PersonResponse extends FCResponse {
   private String email,
       twitter,
       phone,
@@ -25,9 +25,6 @@ public class PersonResponse {
       avatar,
       website;
   private Details details;
-  public boolean isSuccessful;
-  public int statusCode;
-  public String message;
 
   public Optional<Details> getDetails() {
     return Optional.ofNullable(this.details);

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/ResolveResponse.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/ResolveResponse.java
@@ -9,10 +9,7 @@ import java.util.List;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class ResolveResponse {
+public class ResolveResponse extends FCResponse {
   private List<String> recordIds, personIds, partnerIds;
   private List<Tag> tags;
-  public boolean isSuccessful;
-  public int statusCode;
-  public String message;
 }

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/ResolveResponseWithTags.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/ResolveResponseWithTags.java
@@ -10,10 +10,7 @@ import lombok.*;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class ResolveResponseWithTags {
+public class ResolveResponseWithTags extends FCResponse {
   private List<String> recordIds, personIds, partnerIds;
   private Map<String, List<Tag>> tags;
-  public boolean isSuccessful;
-  public int statusCode;
-  public String message;
 }

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/TagsResponse.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Response/TagsResponse.java
@@ -9,10 +9,7 @@ import java.util.List;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class TagsResponse {
+public class TagsResponse extends FCResponse {
   private String recordId, partnerId;
   private List<Tag> tags;
-  public boolean isSuccessful;
-  public int statusCode;
-  public String message;
 }

--- a/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Tag.java
+++ b/java-common-artifacts/src/main/java/com/fullcontact/apilib/models/Tag.java
@@ -6,6 +6,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
+@EqualsAndHashCode
 public class Tag {
   private String key;
   private String value;

--- a/java11/README.md
+++ b/java11/README.md
@@ -14,7 +14,7 @@ API Clients for FullContact on V3 APIs supports Java11+
 Add this dependency to your project's build file:
 
 ```groovy
-implementation 'com.fullcontact.client:java11:2.2.1'
+implementation 'com.fullcontact.client:java11:2.3.0'
 ```
 
 ### Maven users
@@ -25,7 +25,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.fullcontact.client</groupId>
   <artifactId>java11</artifactId>
-  <version>2.2.1</version>
+  <version>2.3.0</version>
 </dependency>
 ```
 

--- a/java11/build.gradle
+++ b/java11/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.fullcontact.client'
-version '2.2.1'
+version '2.3.0'
 
 sourceCompatibility = 11
 

--- a/java11/src/main/java/com/fullcontact/apilib/enrich/FullContact.java
+++ b/java11/src/main/java/com/fullcontact/apilib/enrich/FullContact.java
@@ -143,6 +143,7 @@ public class FullContact implements AutoCloseable {
   public CompletableFuture<PersonResponse> enrich(
       PersonRequest personRequest, RetryHandler retryHandler) throws FullContactException {
     checkForShutdown();
+    personRequest.validate();
     CompletableFuture<HttpResponse<String>> responseCF = new CompletableFuture<>();
     HttpRequest httpRequest =
         this.buildHttpRequest(FCConstants.personEnrichUri, gson.toJson(personRequest));

--- a/java11/src/main/java/com/fullcontact/apilib/enrich/FullContact.java
+++ b/java11/src/main/java/com/fullcontact/apilib/enrich/FullContact.java
@@ -90,8 +90,8 @@ public class FullContact implements AutoCloseable {
   }
 
   /** @return Person Request Builder for Person Enrich request */
-  public static PersonRequest.PersonRequestBuilder buildPersonRequest() {
-    return PersonRequest.builder();
+  public static PersonRequest.PersonRequestBuilder<?, ?> buildPersonRequest() {
+    return PersonRequest.personRequestBuilder();
   }
 
   /** @return Company Request Builder for Company Enrich and Company Search requests */

--- a/java11/src/main/java/com/fullcontact/apilib/enrich/FullContact.java
+++ b/java11/src/main/java/com/fullcontact/apilib/enrich/FullContact.java
@@ -100,8 +100,8 @@ public class FullContact implements AutoCloseable {
   }
 
   /** @return Resolve Request Builder for Resolve */
-  public static ResolveRequest.ResolveRequestBuilder buildResolveRequest() {
-    return ResolveRequest.builder();
+  public static ResolveRequest.ResolveRequestBuilder<?, ?> buildResolveRequest() {
+    return ResolveRequest.resolveRequestBuilder();
   }
 
   /** @return Tags Request Builder for various Tags APIs */

--- a/java11/src/main/java/com/fullcontact/apilib/enrich/FullContact.java
+++ b/java11/src/main/java/com/fullcontact/apilib/enrich/FullContact.java
@@ -12,6 +12,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import lombok.Builder;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -148,7 +149,9 @@ public class FullContact implements AutoCloseable {
     HttpRequest httpRequest =
         this.buildHttpRequest(FCConstants.personEnrichUri, gson.toJson(personRequest));
     sendRequest(httpRequest, retryHandler, responseCF);
-    return responseCF.thenApply(FullContact::getPersonResponse);
+    return responseCF.thenApply(
+        httpResponse ->
+            (PersonResponse) FullContact.getFCResponse(httpResponse, PersonResponse.class));
   }
 
   /**
@@ -181,12 +184,13 @@ public class FullContact implements AutoCloseable {
       CompanyRequest companyRequest, RetryHandler retryHandler) throws FullContactException {
     checkForShutdown();
     companyRequest.validateForEnrich();
-
     CompletableFuture<HttpResponse<String>> responseCF = new CompletableFuture<>();
     HttpRequest httpRequest =
         this.buildHttpRequest(FCConstants.companyEnrichUri, gson.toJson(companyRequest));
     sendRequest(httpRequest, retryHandler, responseCF);
-    return responseCF.thenApply(FullContact::getCompanyResponse);
+    return responseCF.thenApply(
+        httpResponse ->
+            (CompanyResponse) FullContact.getFCResponse(httpResponse, CompanyResponse.class));
   }
 
   /**
@@ -325,7 +329,10 @@ public class FullContact implements AutoCloseable {
     HttpRequest httpRequest =
         this.buildHttpRequest(FCConstants.identityResolveUriWithTags, gson.toJson(resolveRequest));
     sendRequest(httpRequest, retryHandler, responseCF);
-    return responseCF.thenApply(FullContact::getResolveResponseWithTags);
+    return responseCF.thenApply(
+        httpResponse ->
+            (ResolveResponseWithTags)
+                FullContact.getFCResponse(httpResponse, ResolveResponseWithTags.class));
   }
 
   /**
@@ -368,7 +375,9 @@ public class FullContact implements AutoCloseable {
     CompletableFuture<HttpResponse<String>> responseCF = new CompletableFuture<>();
     HttpRequest httpRequest = this.buildHttpRequest(resolveUri, gson.toJson(resolveRequest));
     sendRequest(httpRequest, retryHandler, responseCF);
-    return responseCF.thenApply(FullContact::getResolveResponse);
+    return responseCF.thenApply(
+        httpResponse ->
+            (ResolveResponse) FullContact.getFCResponse(httpResponse, ResolveResponse.class));
   }
 
   /**
@@ -409,7 +418,10 @@ public class FullContact implements AutoCloseable {
                     + "?email="
                     + email));
     sendRequest(httpRequest, retryHandler, responseCF);
-    return responseCF.thenApply(FullContact::getEmailVerificationResponse);
+    return responseCF.thenApply(
+        httpResponse ->
+            (EmailVerificationResponse)
+                FullContact.getFCResponse(httpResponse, EmailVerificationResponse.class));
   }
 
   /**
@@ -446,7 +458,8 @@ public class FullContact implements AutoCloseable {
     HttpRequest httpRequest =
         this.buildHttpRequest(FCConstants.tagsCreateUri, gson.toJson(tagsRequest));
     sendRequest(httpRequest, retryHandler, responseCF);
-    return responseCF.thenApply(FullContact::getTagsResponse);
+    return responseCF.thenApply(
+        httpResponse -> (TagsResponse) FullContact.getFCResponse(httpResponse, TagsResponse.class));
   }
 
   /**
@@ -482,7 +495,8 @@ public class FullContact implements AutoCloseable {
     HttpRequest httpRequest =
         this.buildHttpRequest(FCConstants.tagsGetUri, "{\"recordId\":\"" + recordId + "\"}");
     sendRequest(httpRequest, retryHandler, responseCF);
-    return responseCF.thenApply(FullContact::getTagsResponse);
+    return responseCF.thenApply(
+        httpResponse -> (TagsResponse) FullContact.getFCResponse(httpResponse, TagsResponse.class));
   }
 
   /**
@@ -519,7 +533,8 @@ public class FullContact implements AutoCloseable {
     HttpRequest httpRequest =
         this.buildHttpRequest(FCConstants.tagsDeleteUri, gson.toJson(tagsRequest));
     sendRequest(httpRequest, retryHandler, responseCF);
-    return responseCF.thenApply(FullContact::getTagsResponse);
+    return responseCF.thenApply(
+        httpResponse -> (TagsResponse) FullContact.getFCResponse(httpResponse, TagsResponse.class));
   }
 
   /**
@@ -557,7 +572,9 @@ public class FullContact implements AutoCloseable {
     HttpRequest httpRequest =
         this.buildHttpRequest(FCConstants.audienceCreateUri, gson.toJson(audienceRequest));
     sendRequest(httpRequest, retryHandler, responseCF);
-    return responseCF.thenApply(FullContact::getAudienceResponse);
+    return responseCF.thenApply(
+        httpResponse ->
+            (AudienceResponse) FullContact.getFCResponse(httpResponse, AudienceResponse.class));
   }
 
   /**
@@ -641,57 +658,40 @@ public class FullContact implements AutoCloseable {
   }
 
   /**
-   * This method creates person enrich response and handle for different response codes
+   * This method creates fc response and handle for different response codes
    *
    * @param httpResponse raw response from person enrich API
-   * @return PersonResponse
+   * @param fcResponseClass response class to deserialize
+   * @return FCResponse
    */
-  protected static PersonResponse getPersonResponse(HttpResponse<String> httpResponse) {
-    PersonResponse personResponse;
+  protected static FCResponse getFCResponse(
+      HttpResponse<String> httpResponse, Class<? extends FCResponse> fcResponseClass) {
+    FCResponse fcResponse;
     if (httpResponse.body() != null && !httpResponse.body().trim().isEmpty()) {
-      personResponse = gson.fromJson(httpResponse.body(), PersonResponse.class);
-      if (httpResponse.statusCode() == 200) {
-        personResponse.message = FCConstants.HTTP_RESPONSE_STATUS_200_MESSAGE;
+      fcResponse = gson.fromJson(httpResponse.body(), fcResponseClass);
+      if (httpResponse.statusCode() == 200 || (httpResponse.statusCode() == 204)) {
+        fcResponse.message = FCConstants.HTTP_RESPONSE_STATUS_200_MESSAGE;
       }
     } else {
-      personResponse = new PersonResponse();
+      try {
+        fcResponse = fcResponseClass.getDeclaredConstructor().newInstance();
+      } catch (InstantiationException
+          | IllegalAccessException
+          | NoSuchMethodException
+          | InvocationTargetException e) {
+        fcResponse = new FCResponse();
+      }
       if (httpResponse.statusCode() >= 500) {
-        personResponse.message = FCConstants.HTTP_RESPONSE_STATUS_50X_MESSAGE;
+        fcResponse.message = FCConstants.HTTP_RESPONSE_STATUS_50X_MESSAGE;
       }
     }
-    personResponse.isSuccessful =
+    fcResponse.isSuccessful =
         (httpResponse.statusCode() == 200)
             || (httpResponse.statusCode() == 202)
+            || (httpResponse.statusCode() == 204)
             || (httpResponse.statusCode() == 404);
-    personResponse.statusCode = httpResponse.statusCode();
-    return personResponse;
-  }
-
-  /**
-   * This method creates company enrich response and handle for different response codes
-   *
-   * @param httpResponse raw response from company enrich API
-   * @return CompanyResponse
-   */
-  protected static CompanyResponse getCompanyResponse(HttpResponse<String> httpResponse) {
-    CompanyResponse companyResponse;
-    if (httpResponse.body() != null & !httpResponse.body().trim().isEmpty()) {
-      companyResponse = gson.fromJson(httpResponse.body(), CompanyResponse.class);
-      if (httpResponse.statusCode() == 200) {
-        companyResponse.message = FCConstants.HTTP_RESPONSE_STATUS_200_MESSAGE;
-      }
-    } else {
-      companyResponse = new CompanyResponse();
-      if (httpResponse.statusCode() >= 500) {
-        companyResponse.message = FCConstants.HTTP_RESPONSE_STATUS_50X_MESSAGE;
-      }
-    }
-    companyResponse.isSuccessful =
-        (httpResponse.statusCode() == 200)
-            || (httpResponse.statusCode() == 202)
-            || (httpResponse.statusCode() == 404);
-    companyResponse.statusCode = httpResponse.statusCode();
-    return companyResponse;
+    fcResponse.statusCode = httpResponse.statusCode();
+    return fcResponse;
   }
 
   /**
@@ -723,138 +723,6 @@ public class FullContact implements AutoCloseable {
             || (httpResponse.statusCode() == 404);
     companySearchResponseList.statusCode = httpResponse.statusCode();
     return companySearchResponseList;
-  }
-
-  /**
-   * This method create Resolve response and handle for different response codes
-   *
-   * @param httpResponse raw response from Resolve APIs
-   * @return ResolveResponse
-   */
-  protected static ResolveResponse getResolveResponse(HttpResponse<String> httpResponse) {
-    ResolveResponse resolveResponse;
-    if (httpResponse.body() != null && !httpResponse.body().isBlank()) {
-      resolveResponse = gson.fromJson(httpResponse.body(), ResolveResponse.class);
-      if (httpResponse.statusCode() == 200 || httpResponse.statusCode() == 204) {
-        resolveResponse.message = FCConstants.HTTP_RESPONSE_STATUS_200_MESSAGE;
-      }
-    } else {
-      resolveResponse = new ResolveResponse();
-      if (httpResponse.statusCode() >= 500) {
-        resolveResponse.message = FCConstants.HTTP_RESPONSE_STATUS_50X_MESSAGE;
-      }
-    }
-    resolveResponse.statusCode = httpResponse.statusCode();
-    resolveResponse.isSuccessful =
-        (httpResponse.statusCode() == 200)
-            || (httpResponse.statusCode() == 204)
-            || (httpResponse.statusCode() == 404);
-    return resolveResponse;
-  }
-
-  /**
-   * This method create Resolve response with tags and handle for different response codes
-   *
-   * @param httpResponse raw response from Resolve APIs
-   * @return ResolveResponseWithTags
-   */
-  protected static ResolveResponseWithTags getResolveResponseWithTags(
-      HttpResponse<String> httpResponse) {
-    ResolveResponseWithTags resolveResponseWithTags;
-    if (httpResponse.body() != null && !httpResponse.body().isBlank()) {
-      resolveResponseWithTags = gson.fromJson(httpResponse.body(), ResolveResponseWithTags.class);
-      if (httpResponse.statusCode() == 200 || httpResponse.statusCode() == 204) {
-        resolveResponseWithTags.message = FCConstants.HTTP_RESPONSE_STATUS_200_MESSAGE;
-      }
-    } else {
-      resolveResponseWithTags = new ResolveResponseWithTags();
-      if (httpResponse.statusCode() >= 500) {
-        resolveResponseWithTags.message = FCConstants.HTTP_RESPONSE_STATUS_50X_MESSAGE;
-      }
-    }
-    resolveResponseWithTags.statusCode = httpResponse.statusCode();
-    resolveResponseWithTags.isSuccessful =
-        (httpResponse.statusCode() == 200)
-            || (httpResponse.statusCode() == 204)
-            || (httpResponse.statusCode() == 404);
-    return resolveResponseWithTags;
-  }
-
-  protected static EmailVerificationResponse getEmailVerificationResponse(
-      HttpResponse<String> httpResponse) {
-    EmailVerificationResponse emailVerificationResponse;
-    if (httpResponse.body() != null && !httpResponse.body().trim().isEmpty()) {
-      emailVerificationResponse =
-          gson.fromJson(httpResponse.body(), EmailVerificationResponse.class);
-      if (httpResponse.statusCode() == 200) {
-        emailVerificationResponse.message = FCConstants.HTTP_RESPONSE_STATUS_200_MESSAGE;
-      }
-    } else {
-      emailVerificationResponse = new EmailVerificationResponse();
-      if (httpResponse.statusCode() >= 500) {
-        emailVerificationResponse.message = FCConstants.HTTP_RESPONSE_STATUS_50X_MESSAGE;
-      }
-    }
-    emailVerificationResponse.isSuccessful =
-        (httpResponse.statusCode() == 200)
-            || (httpResponse.statusCode() == 202)
-            || (httpResponse.statusCode() == 404);
-    emailVerificationResponse.statusCode = httpResponse.statusCode();
-    return emailVerificationResponse;
-  }
-
-  /**
-   * This method create Tags response and handle for different response codes
-   *
-   * @param httpResponse raw response from Tags APIs
-   * @return TagsResponse
-   */
-  protected static TagsResponse getTagsResponse(HttpResponse<String> httpResponse) {
-    TagsResponse tagsResponse;
-    if (httpResponse.body() != null && !httpResponse.body().isBlank()) {
-      tagsResponse = gson.fromJson(httpResponse.body(), TagsResponse.class);
-      if (httpResponse.statusCode() == 200 || httpResponse.statusCode() == 204) {
-        tagsResponse.message = FCConstants.HTTP_RESPONSE_STATUS_200_MESSAGE;
-      }
-    } else {
-      tagsResponse = new TagsResponse();
-      if (httpResponse.statusCode() >= 500) {
-        tagsResponse.message = FCConstants.HTTP_RESPONSE_STATUS_50X_MESSAGE;
-      }
-    }
-    tagsResponse.statusCode = httpResponse.statusCode();
-    tagsResponse.isSuccessful =
-        (httpResponse.statusCode() == 200)
-            || (httpResponse.statusCode() == 204)
-            || (httpResponse.statusCode() == 404);
-    return tagsResponse;
-  }
-
-  /**
-   * This method creates Audience response and handle for different response codes
-   *
-   * @param httpResponse raw response from Audience create API
-   * @return AudienceResponse
-   */
-  protected static AudienceResponse getAudienceResponse(HttpResponse<String> httpResponse) {
-    AudienceResponse audienceResponse;
-    if (httpResponse.body() != null && !httpResponse.body().isBlank()) {
-      audienceResponse = gson.fromJson(httpResponse.body(), AudienceResponse.class);
-      if (httpResponse.statusCode() == 200 || httpResponse.statusCode() == 202) {
-        audienceResponse.message = FCConstants.HTTP_RESPONSE_STATUS_200_MESSAGE;
-      }
-    } else {
-      audienceResponse = new AudienceResponse();
-      if (httpResponse.statusCode() >= 500) {
-        audienceResponse.message = FCConstants.HTTP_RESPONSE_STATUS_50X_MESSAGE;
-      }
-    }
-    audienceResponse.statusCode = httpResponse.statusCode();
-    audienceResponse.isSuccessful =
-        (httpResponse.statusCode() == 200)
-            || (httpResponse.statusCode() == 202)
-            || (httpResponse.statusCode() == 404);
-    return audienceResponse;
   }
 
   /**

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/AudienceRequestBuildTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/AudienceRequestBuildTest.java
@@ -34,7 +34,8 @@ public class AudienceRequestBuildTest {
       while ((line = br.readLine()) != null) {
         sb.append(line.trim());
       }
-      Assert.assertEquals(sb.toString(), gson.toJson(audienceRequest));
+      AudienceRequest expectedRequest = gson.fromJson(sb.toString(), AudienceRequest.class);
+      Assert.assertEquals(expectedRequest, audienceRequest);
     }
   }
 

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/AudienceRequestBuildTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/AudienceRequestBuildTest.java
@@ -5,7 +5,9 @@ import com.fullcontact.apilib.models.Request.AudienceRequest;
 import com.fullcontact.apilib.models.Tag;
 import com.google.gson.Gson;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -15,6 +17,7 @@ import java.util.List;
 
 public class AudienceRequestBuildTest {
   private static final Gson gson = new Gson();
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   @Test
   public void AudienceRequestBuildAndSerializeTest() throws FullContactException, IOException {
@@ -40,44 +43,33 @@ public class AudienceRequestBuildTest {
   }
 
   @Test
-  public void invalidAudienceRequestTest1() {
-    try {
-      AudienceRequest audienceRequest = FullContact.buildAudienceRequest().build();
-    } catch (FullContactException e) {
-      Assert.assertEquals("WebhookUrl is mandatory for creating Audience", e.getMessage());
-    }
+  public void invalidAudienceRequestTest1() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("WebhookUrl is mandatory for creating Audience");
+    FullContact.buildAudienceRequest().build();
   }
 
   @Test
-  public void invalidAudienceRequestTest2() {
-    try {
-      AudienceRequest audienceRequest =
-          FullContact.buildAudienceRequest().tag(Tag.builder().value("M").build()).build();
-    } catch (FullContactException e) {
-      Assert.assertEquals("WebhookUrl is mandatory for creating Audience", e.getMessage());
-    }
+  public void invalidAudienceRequestTest2() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("WebhookUrl is mandatory for creating Audience");
+    FullContact.buildAudienceRequest().tag(Tag.builder().value("M").build()).build();
   }
 
   @Test
-  public void invalidAudienceRequestTest3() {
-    try {
-      AudienceRequest audienceRequest =
-          FullContact.buildAudienceRequest().webhookUrl("webhookUrl").build();
-    } catch (FullContactException e) {
-      Assert.assertEquals("At least 1 Tag is mandatory for creating Audience", e.getMessage());
-    }
+  public void invalidAudienceRequestTest3() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("At least 1 Tag is mandatory for creating Audience");
+    FullContact.buildAudienceRequest().webhookUrl("webhookUrl").build();
   }
 
   @Test
-  public void invalidAudienceRequestTest4() {
-    try {
-      AudienceRequest audienceRequest =
-          FullContact.buildAudienceRequest()
-              .webhookUrl("webhookUrl")
-              .tag(Tag.builder().key("key").build())
-              .build();
-    } catch (FullContactException e) {
-      Assert.assertEquals("Both Key and Value must be populated for a Tag", e.getMessage());
-    }
+  public void invalidAudienceRequestTest4() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Both Key and Value must be populated for a Tag");
+    FullContact.buildAudienceRequest()
+        .webhookUrl("webhookUrl")
+        .tag(Tag.builder().key("key").build())
+        .build();
   }
 }

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/AudienceResponseBuildTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/AudienceResponseBuildTest.java
@@ -22,8 +22,10 @@ public class AudienceResponseBuildTest {
   @Test
   public void AudienceResponseModelDeserializationTest1() {
     AudienceResponse response =
-        FullContact.getAudienceResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_401"));
+        (AudienceResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_401"),
+                AudienceResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(200, response.getStatusCode());
     Assert.assertEquals("OK", response.getMessage());
@@ -45,8 +47,10 @@ public class AudienceResponseBuildTest {
   @Test
   public void responseStatus400Test() {
     AudienceResponse response =
-        FullContact.getAudienceResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_002"));
+        (AudienceResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_002"),
+                AudienceResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(400, response.getStatusCode());
     Assert.assertEquals("Unable to process JSON", response.getMessage());
@@ -55,8 +59,10 @@ public class AudienceResponseBuildTest {
   @Test
   public void responseStatus401Test() {
     AudienceResponse response =
-        FullContact.getAudienceResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_004"));
+        (AudienceResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_004"),
+                AudienceResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(401, response.getStatusCode());
     Assert.assertTrue(
@@ -66,8 +72,10 @@ public class AudienceResponseBuildTest {
   @Test
   public void responseStatus404Test() {
     AudienceResponse response =
-        FullContact.getAudienceResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_005"));
+        (AudienceResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_005"),
+                AudienceResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(404, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("Profile not found"));
@@ -76,8 +84,10 @@ public class AudienceResponseBuildTest {
   @Test
   public void responseStatus403Test() {
     AudienceResponse response =
-        FullContact.getAudienceResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_006"));
+        (AudienceResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_006"),
+                AudienceResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(403, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("API Key is missing or invalid."));
@@ -86,8 +96,10 @@ public class AudienceResponseBuildTest {
   @Test
   public void responseStatus422Test() {
     AudienceResponse response =
-        FullContact.getAudienceResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_007"));
+        (AudienceResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_007"),
+                AudienceResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(422, response.getStatusCode());
     Assert.assertTrue(

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/CompanyEnrichResponse.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/CompanyEnrichResponse.java
@@ -9,8 +9,10 @@ public class CompanyEnrichResponse {
   @Test
   public void companyResponseModelDeserializationTest() {
     CompanyResponse response =
-        FullContact.getCompanyResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_051"));
+        (CompanyResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_051"),
+                CompanyResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(200, response.getStatusCode());
     Assert.assertEquals("OK", response.getMessage());
@@ -52,8 +54,10 @@ public class CompanyEnrichResponse {
   @Test
   public void responseStatus400Test() {
     CompanyResponse personResponse =
-        FullContact.getCompanyResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_002"));
+        (CompanyResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_002"),
+                CompanyResponse.class);
     Assert.assertFalse(personResponse.isSuccessful());
     Assert.assertEquals(400, personResponse.getStatusCode());
     Assert.assertEquals("Unable to process JSON", personResponse.getMessage());
@@ -62,8 +66,10 @@ public class CompanyEnrichResponse {
   @Test
   public void responseStatus202Test() {
     CompanyResponse response =
-        FullContact.getCompanyResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_003"));
+        (CompanyResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_003"),
+                CompanyResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(202, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("Queued for search"));
@@ -72,8 +78,10 @@ public class CompanyEnrichResponse {
   @Test
   public void responseStatus401Test() {
     CompanyResponse response =
-        FullContact.getCompanyResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_004"));
+        (CompanyResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_004"),
+                CompanyResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(401, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("401: Invalid access token"));
@@ -82,8 +90,10 @@ public class CompanyEnrichResponse {
   @Test
   public void responseStatus404Test() {
     CompanyResponse response =
-        FullContact.getCompanyResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_005"));
+        (CompanyResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_005"),
+                CompanyResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(404, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("Profile not found"));
@@ -92,8 +102,10 @@ public class CompanyEnrichResponse {
   @Test
   public void responseStatus403Test() {
     CompanyResponse response =
-        FullContact.getCompanyResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_006"));
+        (CompanyResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_006"),
+                CompanyResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(403, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("API Key is missing or invalid."));
@@ -102,8 +114,10 @@ public class CompanyEnrichResponse {
   @Test
   public void responseStatus422Test() {
     CompanyResponse response =
-        FullContact.getCompanyResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_007"));
+        (CompanyResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_007"),
+                CompanyResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(422, response.getStatusCode());
     Assert.assertTrue(

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/CompanyRequestBuildTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/CompanyRequestBuildTest.java
@@ -10,7 +10,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 
-public class ComapanyRequestBuildTest {
+public class CompanyRequestBuildTest {
   private static final Gson gson = new Gson();
 
   @Test
@@ -25,7 +25,8 @@ public class ComapanyRequestBuildTest {
       while ((line = br.readLine()) != null) {
         sb.append(line.trim());
       }
-      Assert.assertEquals(sb.toString(), gson.toJson(companyRequest));
+      CompanyRequest expectedRequest = gson.fromJson(sb.toString(), CompanyRequest.class);
+      Assert.assertEquals(expectedRequest, companyRequest);
     }
   }
 
@@ -49,7 +50,8 @@ public class ComapanyRequestBuildTest {
       while ((line = br.readLine()) != null) {
         sb.append(line.trim());
       }
-      Assert.assertEquals(sb.toString(), gson.toJson(companyRequest));
+      CompanyRequest expectedRequest = gson.fromJson(sb.toString(), CompanyRequest.class);
+      Assert.assertEquals(expectedRequest, companyRequest);
     }
   }
 }

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/EmailVerificationTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/EmailVerificationTest.java
@@ -8,8 +8,10 @@ public class EmailVerificationTest {
   @Test
   public void emailVerificationDeserializationTest() {
     EmailVerificationResponse response =
-        FullContact.getEmailVerificationResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_201"));
+        (EmailVerificationResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_201"),
+                EmailVerificationResponse.class);
     Assert.assertTrue(response.isSuccessful);
     Assert.assertEquals(200, response.getStatus());
     Assert.assertEquals(

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/FullContactClientTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/FullContactClientTest.java
@@ -3,22 +3,21 @@ package com.fullcontact.apilib.enrich;
 import com.fullcontact.apilib.FullContactException;
 import com.fullcontact.apilib.auth.StaticApiKeyCredentialProvider;
 import org.junit.*;
+import org.junit.rules.ExpectedException;
 
 import java.util.HashMap;
 
 public class FullContactClientTest {
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   @Test
-  public void buildClientWithoutKeyTest() {
+  public void buildClientWithoutKeyTest() throws FullContactException {
     HashMap<String, String> customHeader = new HashMap<>();
     customHeader.put("Reporting-Key", "clientXYZ");
-    try {
-      FullContact fcTest = FullContact.builder().headers(customHeader).build();
-      fcTest.close();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Couldn't find valid API Key from ENV variable: FC_API_KEY", fce.getMessage());
-    }
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Couldn't find valid API Key from ENV variable: FC_API_KEY");
+    FullContact fcTest = FullContact.builder().headers(customHeader).build();
+    fcTest.close();
   }
 
   @Test
@@ -34,30 +33,21 @@ public class FullContactClientTest {
   }
 
   @Test
-  public void emptyStaticKeyTest() {
-    try {
-
-      FullContact fcTest =
-          FullContact.builder().credentialsProvider(new StaticApiKeyCredentialProvider("")).build();
-      fcTest.close();
-    } catch (FullContactException e) {
-      Assert.assertEquals("API Key can't be Empty", e.getMessage());
-    }
+  public void emptyStaticKeyTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("API Key can't be Empty");
+    FullContact fcTest =
+        FullContact.builder().credentialsProvider(new StaticApiKeyCredentialProvider("")).build();
+    fcTest.close();
   }
 
   @Test
-  public void nullStaticKeyTest() {
-    try {
-
-      FullContact fcTest =
-          FullContact.builder()
-              .credentialsProvider(new StaticApiKeyCredentialProvider(null))
-              .build();
-      fcTest.close();
-
-    } catch (FullContactException e) {
-      Assert.assertEquals("API Key can't be Empty", e.getMessage());
-    }
+  public void nullStaticKeyTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("API Key can't be Empty");
+    FullContact fcTest =
+        FullContact.builder().credentialsProvider(new StaticApiKeyCredentialProvider(null)).build();
+    fcTest.close();
   }
 
   @Test
@@ -68,5 +58,6 @@ public class FullContactClientTest {
             .connectTimeoutMillis(2000)
             .retryHandler(new CustomRetryHandler())
             .build();
+    fcTest.close();
   }
 }

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/PersonRequestTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/PersonRequestTest.java
@@ -8,7 +8,9 @@ import com.fullcontact.apilib.models.Request.PersonRequest;
 import com.fullcontact.apilib.models.enums.Confidence;
 import com.google.gson.Gson;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -18,6 +20,7 @@ import java.util.List;
 
 public class PersonRequestTest {
   private static final Gson gson = new Gson();
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   @Test
   public void personRequestBuildAndSerializeTest() throws FullContactException, IOException {
@@ -69,115 +72,98 @@ public class PersonRequestTest {
   public void requestWithoutNameAndLocation() throws FullContactException {
     PersonRequest personRequest =
         FullContact.buildPersonRequest().email("marianrd97@outlook.com").build();
+    personRequest.validate();
   }
 
   @Test
-  public void nameWithLocationAsNullTest() {
-    try {
-      PersonRequest personRequest =
-          FullContact.buildPersonRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .build();
-      personRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
-          fce.getMessage());
-    }
+  public void nameWithLocationAsNullTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values");
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .build();
+    personRequest.validate();
   }
 
   @Test
-  public void locationWithNameAsNull() {
-    try {
-      PersonRequest personRequest =
-          FullContact.buildPersonRequest()
-              .location(
-                  Location.builder()
-                      .addressLine1("123/23")
-                      .addressLine2("Some Street")
-                      .city("Denver")
-                      .region("Denver")
-                      .regionCode("123123")
-                      .postalCode("23124")
-                      .build())
-              .build();
-      personRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
-          fce.getMessage());
-    }
+  public void locationWithNameAsNull() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values");
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .location(
+                Location.builder()
+                    .addressLine1("123/23")
+                    .addressLine2("Some Street")
+                    .city("Denver")
+                    .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
+                    .build())
+            .build();
+    personRequest.validate();
   }
 
   @Test
-  public void locationWithNoAddressLine1Test() {
-    try {
-      PersonRequest personRequest =
-          FullContact.buildPersonRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(
-                  Location.builder()
-                      .addressLine2("Some Street")
-                      .city("Denver")
-                      .region("Denver")
-                      .regionCode("123123")
-                      .postalCode("23124")
-                      .build())
-              .build();
-      personRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
+  public void locationWithNoAddressLine1Test() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(
+                Location.builder()
+                    .addressLine2("Some Street")
+                    .city("Denver")
+                    .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
+                    .build())
+            .build();
+    personRequest.validate();
   }
 
   @Test
-  public void locationWithOnlyAddressLine1Test() {
-    try {
-      PersonRequest personRequest =
-          FullContact.buildPersonRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(Location.builder().addressLine1("123/23").build())
-              .build();
-      personRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
+  public void locationWithOnlyAddressLine1Test() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").build())
+            .build();
+    personRequest.validate();
   }
 
   @Test
-  public void locationWithAddressLine1AndCityTest() {
-    try {
-      PersonRequest personRequest =
-          FullContact.buildPersonRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(Location.builder().addressLine1("123/23").city("Denver").build())
-              .build();
-      personRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
+  public void locationWithAddressLine1AndCityTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").city("Denver").build())
+            .build();
+    personRequest.validate();
   }
 
   @Test
-  public void locationWithAddressLine1AndRegionTest() {
-    try {
-      PersonRequest personRequest =
-          FullContact.buildPersonRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(Location.builder().addressLine1("123/23").region("Denver").build())
-              .build();
-      personRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
+  public void locationWithAddressLine1AndRegionTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").region("Denver").build())
+            .build();
+    personRequest.validate();
   }
 
   @Test
@@ -247,46 +233,110 @@ public class PersonRequestTest {
   }
 
   @Test
-  public void profileWithUrlAndUserid() {
-    try {
-      Profile profile =
-          Profile.builder().url("https://twitter.com/mcreedy").userid("mcreedy").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Specifying username or userid together with url is not allowed", fce.getMessage());
-    }
+  public void profileWithUrlAndUserid() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Specifying username or userid together with url is not allowed");
+    Profile.builder().url("https://twitter.com/mcreedy").userid("mcreedy").build();
   }
 
   @Test
-  public void profileWithUrlAndUsername() {
-    try {
-      Profile profile =
-          Profile.builder().url("https://twitter.com/mcreedy").username("mcreedy").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Specifying username or userid together with url is not allowed", fce.getMessage());
-    }
+  public void profileWithUrlAndUsername() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Specifying username or userid ftogether with url is not allowed");
+    Profile.builder().url("https://twitter.com/mcreedy").username("mcreedy").build();
   }
 
   @Test
-  public void profileWithOnlyService() {
-    try {
-      Profile profile = Profile.builder().service("twitter").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Either url or service plus username or userid must be set on every profiles entry.",
-          fce.getMessage());
-    }
+  public void profileWithOnlyService() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Either url or service plus username or userid must be set on every profiles entry.");
+    Profile.builder().service("twitter").build();
   }
 
   @Test
-  public void profileWithServiceAndUseridAndUsername() {
-    try {
-      Profile profile =
-          Profile.builder().service("twitter").userid("mcreedy").username("mcreedy").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Specifying userid together with username is not allowed", fce.getMessage());
-    }
+  public void profileWithServiceAndUseridAndUsername() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Specifying userid together with username is not allowed");
+    Profile.builder().service("twitter").userid("mcreedy").username("mcreedy").build();
+  }
+
+  @Test
+  public void nameWithLocationAsNullWithQueryableTest() throws FullContactException {
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .email("test@fullcontact.com")
+            .build();
+    personRequest.validate();
+  }
+
+  @Test
+  public void locationWithNameAsNullWithQueryableTest() throws FullContactException {
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .location(
+                Location.builder()
+                    .addressLine1("123/23")
+                    .addressLine2("Some Street")
+                    .city("Denver")
+                    .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
+                    .build())
+            .phone("1234567")
+            .build();
+    personRequest.validate();
+  }
+
+  @Test
+  public void locationWithNoAddressLine1WithQueryableTest() throws FullContactException {
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(
+                Location.builder()
+                    .addressLine2("Some Street")
+                    .city("Denver")
+                    .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
+                    .build())
+            .recordId("r1")
+            .build();
+    personRequest.validate();
+  }
+
+  @Test
+  public void locationWithOnlyAddressLine1WithQueryableTest() throws FullContactException {
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").build())
+            .profile(Profile.builder().url("http://linkedin/test").build())
+            .build();
+    personRequest.validate();
+  }
+
+  @Test
+  public void locationWithAddressLine1AndCityWithQueryableTest() throws FullContactException {
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").city("Denver").build())
+            .personId("test")
+            .build();
+    personRequest.validate();
+  }
+
+  @Test
+  public void locationWithAddressLine1AndRegionWithQueryableTest() throws FullContactException {
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").region("Denver").build())
+            .maid("1234-sfnos-3432-sdjnwoi")
+            .build();
+    personRequest.validate();
   }
 }

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/PersonRequestTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/PersonRequestTest.java
@@ -242,7 +242,7 @@ public class PersonRequestTest {
   @Test
   public void profileWithUrlAndUsername() throws FullContactException {
     exceptionRule.expect(FullContactException.class);
-    exceptionRule.expectMessage("Specifying username or userid ftogether with url is not allowed");
+    exceptionRule.expectMessage("Specifying username or userid together with url is not allowed");
     Profile.builder().url("https://twitter.com/mcreedy").username("mcreedy").build();
   }
 

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/PersonRequestTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/PersonRequestTest.java
@@ -60,7 +60,8 @@ public class PersonRequestTest {
       while ((line = br.readLine()) != null) {
         sb.append(line.trim());
       }
-      Assert.assertEquals(sb.toString(), gson.toJson(personRequest));
+      PersonRequest expectedRequest = gson.fromJson(sb.toString(), PersonRequest.class);
+      Assert.assertEquals(expectedRequest, personRequest);
     }
   }
 
@@ -77,6 +78,7 @@ public class PersonRequestTest {
           FullContact.buildPersonRequest()
               .name(PersonName.builder().full("Marian C Reed").build())
               .build();
+      personRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
@@ -99,6 +101,7 @@ public class PersonRequestTest {
                       .postalCode("23124")
                       .build())
               .build();
+      personRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
@@ -121,6 +124,7 @@ public class PersonRequestTest {
                       .postalCode("23124")
                       .build())
               .build();
+      personRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
@@ -136,6 +140,7 @@ public class PersonRequestTest {
               .name(PersonName.builder().full("Marian C Reed").build())
               .location(Location.builder().addressLine1("123/23").build())
               .build();
+      personRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
@@ -151,6 +156,7 @@ public class PersonRequestTest {
               .name(PersonName.builder().full("Marian C Reed").build())
               .location(Location.builder().addressLine1("123/23").city("Denver").build())
               .build();
+      personRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
@@ -166,6 +172,7 @@ public class PersonRequestTest {
               .name(PersonName.builder().full("Marian C Reed").build())
               .location(Location.builder().addressLine1("123/23").region("Denver").build())
               .build();
+      personRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/PersonResponseTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/PersonResponseTest.java
@@ -9,8 +9,10 @@ public class PersonResponseTest {
   @Test
   public void personResponseModelDeserializationTest() {
     PersonResponse response =
-        FullContact.getPersonResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_001"));
+        (PersonResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_001"),
+                PersonResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(200, response.getStatusCode());
     Assert.assertEquals("OK", response.getMessage());
@@ -143,8 +145,10 @@ public class PersonResponseTest {
   @Test
   public void responseStatus400Test() {
     PersonResponse personResponse =
-        FullContact.getPersonResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_002"));
+        (PersonResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_002"),
+                PersonResponse.class);
     Assert.assertFalse(personResponse.isSuccessful());
     Assert.assertEquals(400, personResponse.getStatusCode());
     Assert.assertEquals("Unable to process JSON", personResponse.getMessage());
@@ -153,8 +157,10 @@ public class PersonResponseTest {
   @Test
   public void responseStatus202Test() {
     PersonResponse response =
-        FullContact.getPersonResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_003"));
+        (PersonResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_003"),
+                PersonResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(202, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("Queued for search"));
@@ -163,8 +169,10 @@ public class PersonResponseTest {
   @Test
   public void responseStatus401Test() {
     PersonResponse response =
-        FullContact.getPersonResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_004"));
+        (PersonResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_004"),
+                PersonResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(401, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("401: Invalid access token"));
@@ -173,8 +181,10 @@ public class PersonResponseTest {
   @Test
   public void responseStatus404Test() {
     PersonResponse response =
-        FullContact.getPersonResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_005"));
+        (PersonResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_005"),
+                PersonResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(404, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("Profile not found"));
@@ -183,8 +193,10 @@ public class PersonResponseTest {
   @Test
   public void responseStatus403Test() {
     PersonResponse response =
-        FullContact.getPersonResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_006"));
+        (PersonResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_006"),
+                PersonResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(403, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("API Key is missing or invalid."));
@@ -193,8 +205,10 @@ public class PersonResponseTest {
   @Test
   public void responseStatus422Test() {
     PersonResponse response =
-        FullContact.getPersonResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_007"));
+        (PersonResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_007"),
+                PersonResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(422, response.getStatusCode());
     Assert.assertTrue(

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/ResolveRequestBuildTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/ResolveRequestBuildTest.java
@@ -53,7 +53,8 @@ public class ResolveRequestBuildTest {
       while ((line = br.readLine()) != null) {
         sb.append(line.trim());
       }
-      Assert.assertEquals(sb.toString(), gson.toJson(resolveRequest));
+      ResolveRequest expectedRequest = gson.fromJson(sb.toString(), ResolveRequest.class);
+      Assert.assertEquals(expectedRequest, resolveRequest);
     }
   }
 
@@ -70,6 +71,7 @@ public class ResolveRequestBuildTest {
           FullContact.buildResolveRequest()
               .name(PersonName.builder().full("Marian C Reed").build())
               .build();
+      resolveRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
@@ -92,6 +94,7 @@ public class ResolveRequestBuildTest {
                       .postalCode("23124")
                       .build())
               .build();
+      resolveRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
@@ -114,6 +117,7 @@ public class ResolveRequestBuildTest {
                       .postalCode("23124")
                       .build())
               .build();
+      resolveRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
@@ -129,6 +133,7 @@ public class ResolveRequestBuildTest {
               .name(PersonName.builder().full("Marian C Reed").build())
               .location(Location.builder().addressLine1("123/23").build())
               .build();
+      resolveRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
@@ -144,6 +149,7 @@ public class ResolveRequestBuildTest {
               .name(PersonName.builder().full("Marian C Reed").build())
               .location(Location.builder().addressLine1("123/23").city("Denver").build())
               .build();
+      resolveRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
@@ -159,6 +165,7 @@ public class ResolveRequestBuildTest {
               .name(PersonName.builder().full("Marian C Reed").build())
               .location(Location.builder().addressLine1("123/23").region("Denver").build())
               .build();
+      resolveRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/ResolveRequestBuildTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/ResolveRequestBuildTest.java
@@ -8,7 +8,9 @@ import com.fullcontact.apilib.models.Request.ResolveRequest;
 import com.fullcontact.apilib.models.Tag;
 import com.google.gson.Gson;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -18,6 +20,7 @@ import java.util.List;
 
 public class ResolveRequestBuildTest {
   private static final Gson gson = new Gson();
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   @Test
   public void personRequestBuildAndSerializeTest() throws FullContactException, IOException {
@@ -62,115 +65,98 @@ public class ResolveRequestBuildTest {
   public void requestWithoutNameAndLocation() throws FullContactException {
     ResolveRequest resolveRequest =
         FullContact.buildResolveRequest().email("marianrd97@outlook.com").build();
+    resolveRequest.validate();
   }
 
   @Test
-  public void nameWithLocationAsNullTest() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .build();
-      resolveRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
-          fce.getMessage());
-    }
+  public void nameWithLocationAsNullTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .build();
+    resolveRequest.validate();
   }
 
   @Test
-  public void locationWithNameAsNull() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest()
-              .location(
-                  Location.builder()
-                      .addressLine1("123/23")
-                      .addressLine2("Some Street")
-                      .city("Denver")
-                      .region("Denver")
-                      .regionCode("123123")
-                      .postalCode("23124")
-                      .build())
-              .build();
-      resolveRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
-          fce.getMessage());
-    }
+  public void locationWithNameAsNull() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .location(
+                Location.builder()
+                    .addressLine1("123/23")
+                    .addressLine2("Some Street")
+                    .city("Denver")
+                    .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
+                    .build())
+            .build();
+    resolveRequest.validate();
   }
 
   @Test
-  public void locationWithNoAddressLine1Test() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(
-                  Location.builder()
-                      .addressLine2("Some Street")
-                      .city("Denver")
-                      .region("Denver")
-                      .regionCode("123123")
-                      .postalCode("23124")
-                      .build())
-              .build();
-      resolveRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
+  public void locationWithNoAddressLine1Test() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(
+                Location.builder()
+                    .addressLine2("Some Street")
+                    .city("Denver")
+                    .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
+                    .build())
+            .build();
+    resolveRequest.validate();
   }
 
   @Test
-  public void locationWithOnlyAddressLine1Test() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(Location.builder().addressLine1("123/23").build())
-              .build();
-      resolveRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
+  public void locationWithOnlyAddressLine1Test() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").build())
+            .build();
+    resolveRequest.validate();
   }
 
   @Test
-  public void locationWithAddressLine1AndCityTest() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(Location.builder().addressLine1("123/23").city("Denver").build())
-              .build();
-      resolveRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
+  public void locationWithAddressLine1AndCityTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").city("Denver").build())
+            .build();
+    resolveRequest.validate();
   }
 
   @Test
-  public void locationWithAddressLine1AndRegionTest() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(Location.builder().addressLine1("123/23").region("Denver").build())
-              .build();
-      resolveRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
+  public void locationWithAddressLine1AndRegionTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").region("Denver").build())
+            .build();
+    resolveRequest.validate();
   }
 
   @Test
@@ -180,6 +166,7 @@ public class ResolveRequestBuildTest {
             .name(PersonName.builder().full("Marian C Reed").build())
             .location(Location.builder().addressLine1("123/23").postalCode("23124").build())
             .build();
+    resolveRequest.validate();
   }
 
   @Test
@@ -195,6 +182,7 @@ public class ResolveRequestBuildTest {
                     .region("Denver")
                     .build())
             .build();
+    resolveRequest.validate();
   }
 
   @Test
@@ -209,6 +197,7 @@ public class ResolveRequestBuildTest {
                     .regionCode("123123")
                     .build())
             .build();
+    resolveRequest.validate();
   }
 
   @Test
@@ -218,6 +207,7 @@ public class ResolveRequestBuildTest {
             .name(PersonName.builder().given("Marian").family("Reed").build())
             .location(Location.builder().addressLine1("123/23").postalCode("23124").build())
             .build();
+    resolveRequest.validate();
   }
 
   @Test
@@ -226,105 +216,81 @@ public class ResolveRequestBuildTest {
         FullContact.buildResolveRequest()
             .profile(Profile.builder().url("https://twitter.com/mcreedy").build())
             .build();
+    resolveRequest.validate();
   }
 
   @Test
   public void validProfileBuilder2Test() throws FullContactException {
-    Profile profile = Profile.builder().service("twitter").url("mcreedy").build();
+    Profile.builder().service("twitter").url("mcreedy").build();
   }
 
   @Test
   public void validProfileBuilder3Test() throws FullContactException {
-    Profile profile = Profile.builder().service("twitter").username("mcreedy").build();
+    Profile.builder().service("twitter").username("mcreedy").build();
   }
 
   @Test
-  public void profileWithUrlAndUserid() {
-    try {
-      Profile profile =
-          Profile.builder().url("https://twitter.com/mcreedy").userid("mcreedy").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Specifying username or userid together with url is not allowed", fce.getMessage());
-    }
+  public void profileWithUrlAndUserid() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Specifying username or userid together with url is not allowed");
+    Profile.builder().url("https://twitter.com/mcreedy").userid("mcreedy").build();
   }
 
   @Test
-  public void profileWithUrlAndUsername() {
-    try {
-      Profile profile =
-          Profile.builder().url("https://twitter.com/mcreedy").username("mcreedy").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Specifying username or userid together with url is not allowed", fce.getMessage());
-    }
+  public void profileWithUrlAndUsername() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Specifying username or userid together with url is not allowed");
+    Profile.builder().url("https://twitter.com/mcreedy").username("mcreedy").build();
   }
 
   @Test
-  public void profileWithOnlyService() {
-    try {
-      Profile profile = Profile.builder().service("twitter").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Either url or service plus username or userid must be set on every profiles entry.",
-          fce.getMessage());
-    }
+  public void profileWithOnlyService() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Either url or service plus username or userid must be set on every profiles entry.");
+    Profile.builder().service("twitter").build();
   }
 
   @Test
-  public void profileWithServiceAndUseridAndUsername() {
-    try {
-      Profile profile =
-          Profile.builder().service("twitter").userid("mcreedy").userid("mcreedy").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Specifying userid together with username is not allowed", fce.getMessage());
-    }
+  public void profileWithServiceAndUseridAndUsername() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Specifying userid together with username is not allowed");
+    Profile.builder().service("twitter").userid("mcreedy").username("mcreedy").build();
   }
 
   @Test
-  public void identityMapRequestWithPersonId() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest().email("test").personId("test").build();
-      resolveRequest.validateForIdentityMap();
-    } catch (FullContactException fce) {
-      Assert.assertEquals("Invalid map request, person id must be empty", fce.getMessage());
-    }
+  public void identityMapRequestWithPersonId() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Invalid map request, person id must be empty");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest().email("test").personId("test").build();
+    resolveRequest.validateForIdentityMap();
   }
 
   @Test
-  public void identityMapRequestWithOnlyRecordId() {
-    try {
-      ResolveRequest resolveRequest = FullContact.buildResolveRequest().recordId("test").build();
-      resolveRequest.validateForIdentityMap();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Invalid map request, Any of Email, Phone, SocialProfile, Name and Location must be present",
-          fce.getMessage());
-    }
+  public void identityMapRequestWithOnlyRecordId() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Invalid map request, Any of Email, Phone, SocialProfile, Name and Location must be present");
+    ResolveRequest resolveRequest = FullContact.buildResolveRequest().recordId("test").build();
+    resolveRequest.validateForIdentityMap();
   }
 
   @Test
-  public void identityResolveRequestWithRecordIdAndPersonId() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest().recordId("test").personId("test").build();
-      resolveRequest.validateForIdentityResolve();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Both record id and person id are populated, please select one", fce.getMessage());
-    }
+  public void identityResolveRequestWithRecordIdAndPersonId() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Both record id and person id are populated, please select one");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest().recordId("test").personId("test").build();
+    resolveRequest.validateForIdentityResolve();
   }
 
   @Test
-  public void identityDeleteRequestWithNoRecordId() {
-    try {
-      ResolveRequest resolveRequest = FullContact.buildResolveRequest().personId("test").build();
-      resolveRequest.validateForIdentityDelete();
-    } catch (FullContactException fce) {
-      Assert.assertEquals("recordId param must be specified", fce.getMessage());
-    }
+  public void identityDeleteRequestWithNoRecordId() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("recordId param must be specified");
+    ResolveRequest resolveRequest = FullContact.buildResolveRequest().personId("test").build();
+    resolveRequest.validateForIdentityDelete();
   }
 
   @Test
@@ -339,18 +305,94 @@ public class ResolveRequestBuildTest {
   }
 
   @Test
-  public void identityMapWithInvalidTags() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest()
-              .recordId("test")
-              .email("test")
-              .tag(Tag.builder().key("key").build())
-              .build();
-      resolveRequest.validateForIdentityMap();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Both Key and Value must be populated for adding a Tag", fce.getMessage());
-    }
+  public void identityMapWithInvalidTags() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Both Key and Value must be populated for adding a Tag");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .recordId("test")
+            .email("test")
+            .tag(Tag.builder().key("key").build())
+            .build();
+    resolveRequest.validateForIdentityMap();
+  }
+
+  @Test
+  public void nameWithLocationAsNullWithQueryableTest() throws FullContactException {
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .email("test@fullcontact.com")
+            .build();
+    resolveRequest.validate();
+  }
+
+  @Test
+  public void locationWithNameAsNullWithQueryableTest() throws FullContactException {
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .location(
+                Location.builder()
+                    .addressLine1("123/23")
+                    .addressLine2("Some Street")
+                    .city("Denver")
+                    .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
+                    .build())
+            .phone("1234567")
+            .build();
+    resolveRequest.validate();
+  }
+
+  @Test
+  public void locationWithNoAddressLine1WithQueryableTest() throws FullContactException {
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(
+                Location.builder()
+                    .addressLine2("Some Street")
+                    .city("Denver")
+                    .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
+                    .build())
+            .recordId("r1")
+            .build();
+    resolveRequest.validate();
+  }
+
+  @Test
+  public void locationWithOnlyAddressLine1WithQueryableTest() throws FullContactException {
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").build())
+            .maid("12334-sdnosf-23423-sldfsi")
+            .build();
+    resolveRequest.validate();
+  }
+
+  @Test
+  public void locationWithAddressLine1AndCityWithQueryableTest() throws FullContactException {
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").city("Denver").build())
+            .profile(Profile.builder().url("http://linkedin/test").build())
+            .build();
+    resolveRequest.validate();
+  }
+
+  @Test
+  public void locationWithAddressLine1AndRegionWithQueryableTest() throws FullContactException {
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").region("Denver").build())
+            .li_nonid("3iruhow1039oijwe")
+            .build();
+    resolveRequest.validate();
   }
 }

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/ResolveResponseTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/ResolveResponseTest.java
@@ -25,8 +25,10 @@ public class ResolveResponseTest {
   @Test
   public void resolveResponseModelDeserializationTest1() {
     ResolveResponse response =
-        FullContact.getResolveResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_101"));
+        (ResolveResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_101"),
+                ResolveResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(200, response.getStatusCode());
     Assert.assertEquals("OK", response.getMessage());
@@ -37,8 +39,10 @@ public class ResolveResponseTest {
   @Test
   public void resolveResponseModelDeserializationTest2() {
     ResolveResponse response =
-        FullContact.getResolveResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_102"));
+        (ResolveResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_102"),
+                ResolveResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(200, response.getStatusCode());
     Assert.assertEquals("OK", response.getMessage());
@@ -50,8 +54,10 @@ public class ResolveResponseTest {
   @Test
   public void identityDeleteTest() {
     ResolveResponse response =
-        FullContact.getResolveResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_103"));
+        (ResolveResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_103"),
+                ResolveResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(204, response.getStatusCode());
     Assert.assertEquals("OK", response.getMessage());
@@ -62,8 +68,10 @@ public class ResolveResponseTest {
   @Test
   public void responseStatus400Test() {
     ResolveResponse personResponse =
-        FullContact.getResolveResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_002"));
+        (ResolveResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_002"),
+                ResolveResponse.class);
     Assert.assertFalse(personResponse.isSuccessful());
     Assert.assertEquals(400, personResponse.getStatusCode());
     Assert.assertEquals("Unable to process JSON", personResponse.getMessage());
@@ -72,8 +80,10 @@ public class ResolveResponseTest {
   @Test
   public void responseStatus401Test() {
     ResolveResponse response =
-        FullContact.getResolveResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_004"));
+        (ResolveResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_004"),
+                ResolveResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(401, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("401: Invalid access token"));
@@ -82,8 +92,10 @@ public class ResolveResponseTest {
   @Test
   public void responseStatus404Test() {
     ResolveResponse response =
-        FullContact.getResolveResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_005"));
+        (ResolveResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_005"),
+                ResolveResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(404, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("Profile not found"));
@@ -92,8 +104,10 @@ public class ResolveResponseTest {
   @Test
   public void responseStatus403Test() {
     ResolveResponse response =
-        FullContact.getResolveResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_006"));
+        (ResolveResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_006"),
+                ResolveResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(403, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("API Key is missing or invalid."));
@@ -102,8 +116,10 @@ public class ResolveResponseTest {
   @Test
   public void responseStatus422Test() {
     ResolveResponse response =
-        FullContact.getResolveResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_007"));
+        (ResolveResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_007"),
+                ResolveResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(422, response.getStatusCode());
     Assert.assertTrue(
@@ -115,8 +131,10 @@ public class ResolveResponseTest {
   @Test
   public void resolveResponseWithTagsModelDeserializationTest() {
     ResolveResponseWithTags response =
-        FullContact.getResolveResponseWithTags(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_104"));
+        (ResolveResponseWithTags)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_104"),
+                ResolveResponseWithTags.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(200, response.getStatusCode());
     Assert.assertEquals("OK", response.getMessage());

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/TagsRequestBuildTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/TagsRequestBuildTest.java
@@ -5,7 +5,9 @@ import com.fullcontact.apilib.models.Request.TagsRequest;
 import com.fullcontact.apilib.models.Tag;
 import com.google.gson.Gson;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -15,6 +17,7 @@ import java.util.List;
 
 public class TagsRequestBuildTest {
   private static final Gson gson = new Gson();
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   @Test
   public void tagsRequestBuildAndSerializeTest() throws FullContactException, IOException {
@@ -40,38 +43,30 @@ public class TagsRequestBuildTest {
   }
 
   @Test
-  public void invalidTagsRequestTest1() {
-    try {
-      TagsRequest tagsRequest =
-          FullContact.buildTagsRequest()
-              .recordId("customer123")
-              .tag(Tag.builder().key("gender").build())
-              .build();
-    } catch (FullContactException e) {
-      Assert.assertEquals("Both Key and Value must be populated for adding a Tag", e.getMessage());
-    }
+  public void invalidTagsRequestTest1() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Both Key and Value must be populated for adding a Tag");
+    FullContact.buildTagsRequest()
+        .recordId("customer123")
+        .tag(Tag.builder().key("gender").build())
+        .build();
   }
 
   @Test
-  public void invalidTagsRequestTest2() {
-    try {
-      TagsRequest tagsRequest =
-          FullContact.buildTagsRequest()
-              .recordId("customer123")
-              .tag(Tag.builder().value("M").build())
-              .build();
-    } catch (FullContactException e) {
-      Assert.assertEquals("Both Key and Value must be populated for adding a Tag", e.getMessage());
-    }
+  public void invalidTagsRequestTest2() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Both Key and Value must be populated for adding a Tag");
+    TagsRequest tagsRequest =
+        FullContact.buildTagsRequest()
+            .recordId("customer123")
+            .tag(Tag.builder().value("M").build())
+            .build();
   }
 
   @Test
-  public void invalidTagsRequestTest3() {
-    try {
-      TagsRequest tagsRequest =
-          FullContact.buildTagsRequest().tag(Tag.builder().key("G").value("M").build()).build();
-    } catch (FullContactException e) {
-      Assert.assertEquals("RecordId must be present for creating Tags", e.getMessage());
-    }
+  public void invalidTagsRequestTest3() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("RecordId must be present for creating Tags");
+    FullContact.buildTagsRequest().tag(Tag.builder().key("G").value("M").build()).build();
   }
 }

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/TagsRequestBuildTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/TagsRequestBuildTest.java
@@ -34,7 +34,8 @@ public class TagsRequestBuildTest {
       while ((line = br.readLine()) != null) {
         sb.append(line.trim());
       }
-      Assert.assertEquals(sb.toString(), gson.toJson(tagsRequest));
+      TagsRequest expectedRequest = gson.fromJson(sb.toString(), TagsRequest.class);
+      Assert.assertEquals(expectedRequest, tagsRequest);
     }
   }
 

--- a/java11/src/test/java/com/fullcontact/apilib/enrich/TagsResponseTest.java
+++ b/java11/src/test/java/com/fullcontact/apilib/enrich/TagsResponseTest.java
@@ -21,8 +21,10 @@ public class TagsResponseTest {
   @Test
   public void tagsResponseModelDeserializationTest1() {
     TagsResponse response =
-        FullContact.getTagsResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_301"));
+        (TagsResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_301"),
+                TagsResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(200, response.getStatusCode());
     Assert.assertEquals("OK", response.getMessage());
@@ -33,8 +35,10 @@ public class TagsResponseTest {
   @Test
   public void tagsResponseModelDeserializationTest2() {
     TagsResponse response =
-        FullContact.getTagsResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_302"));
+        (TagsResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_302"),
+                TagsResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(200, response.getStatusCode());
     Assert.assertEquals("OK", response.getMessage());
@@ -45,8 +49,10 @@ public class TagsResponseTest {
   @Test
   public void tagsDeleteTest() {
     TagsResponse response =
-        FullContact.getTagsResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_303"));
+        (TagsResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_303"),
+                TagsResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(204, response.getStatusCode());
     Assert.assertEquals("OK", response.getMessage());
@@ -55,8 +61,10 @@ public class TagsResponseTest {
   @Test
   public void responseStatus400Test() {
     TagsResponse response =
-        FullContact.getTagsResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_002"));
+        (TagsResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_002"),
+                TagsResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(400, response.getStatusCode());
     Assert.assertEquals("Unable to process JSON", response.getMessage());
@@ -65,8 +73,10 @@ public class TagsResponseTest {
   @Test
   public void responseStatus401Test() {
     TagsResponse response =
-        FullContact.getTagsResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_004"));
+        (TagsResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_004"),
+                TagsResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(401, response.getStatusCode());
     Assert.assertTrue(
@@ -76,8 +86,10 @@ public class TagsResponseTest {
   @Test
   public void responseStatus404Test() {
     TagsResponse response =
-        FullContact.getTagsResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_005"));
+        (TagsResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_005"),
+                TagsResponse.class);
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(404, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("Profile not found"));
@@ -86,8 +98,10 @@ public class TagsResponseTest {
   @Test
   public void responseStatus403Test() {
     TagsResponse response =
-        FullContact.getTagsResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_006"));
+        (TagsResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_006"),
+                TagsResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(403, response.getStatusCode());
     Assert.assertTrue(response.getMessage().contains("API Key is missing or invalid."));
@@ -96,8 +110,10 @@ public class TagsResponseTest {
   @Test
   public void responseStatus422Test() {
     TagsResponse response =
-        FullContact.getTagsResponse(
-            HttpResponseTestObjects.httpResponseTestObjectProvider("tc_007"));
+        (TagsResponse)
+            FullContact.getFCResponse(
+                HttpResponseTestObjects.httpResponseTestObjectProvider("tc_007"),
+                TagsResponse.class);
     Assert.assertFalse(response.isSuccessful());
     Assert.assertEquals(422, response.getStatusCode());
     Assert.assertTrue(

--- a/java8/README.md
+++ b/java8/README.md
@@ -14,7 +14,7 @@ API Clients for FullContact on V3 APIs supports Java8+
 Add this dependency to your project's build file:
 
 ```groovy
-implementation 'com.fullcontact.client:java8:2.2.1'
+implementation 'com.fullcontact.client:java8:2.3.0'
 ```
 
 ### Maven users
@@ -25,7 +25,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.fullcontact.client</groupId>
   <artifactId>java8</artifactId>
-  <version>2.2.1</version>
+  <version>2.3.0</version>
 </dependency>
 ```
 

--- a/java8/build.gradle
+++ b/java8/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.fullcontact.client'
-version '2.2.1'
+version '2.3.0'
 
 sourceCompatibility = 1.8
 

--- a/java8/src/main/java/com/fullcontact/apilib/enrich/FullContact.java
+++ b/java8/src/main/java/com/fullcontact/apilib/enrich/FullContact.java
@@ -1026,8 +1026,8 @@ public class FullContact implements AutoCloseable {
   }
 
   /** @return Person Request Builder for Person Enrich request */
-  public static PersonRequest.PersonRequestBuilder buildPersonRequest() {
-    return PersonRequest.builder();
+  public static PersonRequest.PersonRequestBuilder<?, ?> buildPersonRequest() {
+    return PersonRequest.personRequestBuilder();
   }
 
   /** @return Company Request Builder for Company Enrich and Company Search requests */
@@ -1036,8 +1036,8 @@ public class FullContact implements AutoCloseable {
   }
 
   /** @return Resolve Request Builder for Resolve */
-  public static ResolveRequest.ResolveRequestBuilder buildResolveRequest() {
-    return ResolveRequest.builder();
+  public static ResolveRequest.ResolveRequestBuilder<?, ?> buildResolveRequest() {
+    return ResolveRequest.resolveRequestBuilder();
   }
 
   /** @return TagsRequest Builder for various tags endpoints */

--- a/java8/src/main/java/com/fullcontact/apilib/enrich/FullContact.java
+++ b/java8/src/main/java/com/fullcontact/apilib/enrich/FullContact.java
@@ -148,6 +148,7 @@ public class FullContact implements AutoCloseable {
   public CompletableFuture<PersonResponse> enrich(
       PersonRequest personRequest, RetryHandler retryHandler) throws FullContactException {
     checkForShutdown();
+    personRequest.validate();
     CompletableFuture<Response<ResponseBody>> responseCF = new CompletableFuture<>();
     RequestBody httpRequest = buildHttpRequest(gson.toJson(personRequest));
     CompletableFuture<Response<ResponseBody>> httpResponseCompletableFuture =

--- a/java8/src/test/java/com/fullcontact/apilib/enrich/AudienceRequestBuildTest.java
+++ b/java8/src/test/java/com/fullcontact/apilib/enrich/AudienceRequestBuildTest.java
@@ -34,7 +34,8 @@ public class AudienceRequestBuildTest {
       while ((line = br.readLine()) != null) {
         sb.append(line.trim());
       }
-      Assert.assertEquals(sb.toString(), gson.toJson(audienceRequest));
+      AudienceRequest expectedRequest = gson.fromJson(sb.toString(), AudienceRequest.class);
+      Assert.assertEquals(expectedRequest, audienceRequest);
     }
   }
 

--- a/java8/src/test/java/com/fullcontact/apilib/enrich/AudienceRequestBuildTest.java
+++ b/java8/src/test/java/com/fullcontact/apilib/enrich/AudienceRequestBuildTest.java
@@ -5,7 +5,9 @@ import com.fullcontact.apilib.models.Request.AudienceRequest;
 import com.fullcontact.apilib.models.Tag;
 import com.google.gson.Gson;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -15,6 +17,7 @@ import java.util.List;
 
 public class AudienceRequestBuildTest {
   private static final Gson gson = new Gson();
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   @Test
   public void AudienceRequestBuildAndSerializeTest() throws FullContactException, IOException {
@@ -40,44 +43,33 @@ public class AudienceRequestBuildTest {
   }
 
   @Test
-  public void invalidAudienceRequestTest1() {
-    try {
-      AudienceRequest audienceRequest = FullContact.buildAudienceRequest().build();
-    } catch (FullContactException e) {
-      Assert.assertEquals("WebhookUrl is mandatory for creating Audience", e.getMessage());
-    }
+  public void invalidAudienceRequestTest1() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("WebhookUrl is mandatory for creating Audience");
+    FullContact.buildAudienceRequest().build();
   }
 
   @Test
-  public void invalidAudienceRequestTest2() {
-    try {
-      AudienceRequest audienceRequest =
-          FullContact.buildAudienceRequest().tag(Tag.builder().value("M").build()).build();
-    } catch (FullContactException e) {
-      Assert.assertEquals("WebhookUrl is mandatory for creating Audience", e.getMessage());
-    }
+  public void invalidAudienceRequestTest2() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("WebhookUrl is mandatory for creating Audience");
+    FullContact.buildAudienceRequest().tag(Tag.builder().value("M").build()).build();
   }
 
   @Test
-  public void invalidAudienceRequestTest3() {
-    try {
-      AudienceRequest audienceRequest =
-          FullContact.buildAudienceRequest().webhookUrl("webhookUrl").build();
-    } catch (FullContactException e) {
-      Assert.assertEquals("At least 1 Tag is mandatory for creating Audience", e.getMessage());
-    }
+  public void invalidAudienceRequestTest3() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("At least 1 Tag is mandatory for creating Audience");
+    FullContact.buildAudienceRequest().webhookUrl("webhookUrl").build();
   }
 
   @Test
-  public void invalidAudienceRequestTest4() {
-    try {
-      AudienceRequest audienceRequest =
-          FullContact.buildAudienceRequest()
-              .webhookUrl("webhookUrl")
-              .tag(Tag.builder().key("key").build())
-              .build();
-    } catch (FullContactException e) {
-      Assert.assertEquals("Both Key and Value must be populated for a Tag", e.getMessage());
-    }
+  public void invalidAudienceRequestTest4() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Both Key and Value must be populated for a Tag");
+    FullContact.buildAudienceRequest()
+        .webhookUrl("webhookUrl")
+        .tag(Tag.builder().key("key").build())
+        .build();
   }
 }

--- a/java8/src/test/java/com/fullcontact/apilib/enrich/CompanyRequestBuildTest.java
+++ b/java8/src/test/java/com/fullcontact/apilib/enrich/CompanyRequestBuildTest.java
@@ -10,7 +10,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 
-public class ComapanyRequestBuildTest {
+public class CompanyRequestBuildTest {
   private static final Gson gson = new Gson();
 
   @Test
@@ -25,7 +25,8 @@ public class ComapanyRequestBuildTest {
       while ((line = br.readLine()) != null) {
         sb.append(line.trim());
       }
-      Assert.assertEquals(sb.toString(), gson.toJson(companyRequest));
+      CompanyRequest expectedRequest = gson.fromJson(sb.toString(), CompanyRequest.class);
+      Assert.assertEquals(expectedRequest, companyRequest);
     }
   }
 
@@ -49,7 +50,8 @@ public class ComapanyRequestBuildTest {
       while ((line = br.readLine()) != null) {
         sb.append(line.trim());
       }
-      Assert.assertEquals(sb.toString(), gson.toJson(companyRequest));
+      CompanyRequest expectedRequest = gson.fromJson(sb.toString(), CompanyRequest.class);
+      Assert.assertEquals(expectedRequest, companyRequest);
     }
   }
 }

--- a/java8/src/test/java/com/fullcontact/apilib/enrich/FullContactClientTest.java
+++ b/java8/src/test/java/com/fullcontact/apilib/enrich/FullContactClientTest.java
@@ -3,22 +3,21 @@ package com.fullcontact.apilib.enrich;
 import com.fullcontact.apilib.FullContactException;
 import com.fullcontact.apilib.auth.StaticApiKeyCredentialProvider;
 import org.junit.*;
+import org.junit.rules.ExpectedException;
 
 import java.util.HashMap;
 
 public class FullContactClientTest {
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   @Test
-  public void buildClientWithoutKeyTest() {
+  public void buildClientWithoutKeyTest() throws FullContactException {
     HashMap<String, String> customHeader = new HashMap<>();
     customHeader.put("Reporting-Key", "clientXYZ");
-    try {
-      FullContact fcTest = FullContact.builder().headers(customHeader).build();
-      fcTest.close();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Couldn't find valid API Key from ENV variable: FC_API_KEY", fce.getMessage());
-    }
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Couldn't find valid API Key from ENV variable: FC_API_KEY");
+    FullContact fcTest = FullContact.builder().headers(customHeader).build();
+    fcTest.close();
   }
 
   @Test
@@ -34,30 +33,21 @@ public class FullContactClientTest {
   }
 
   @Test
-  public void emptyStaticKeyTest() {
-    try {
-
-      FullContact fcTest =
-          FullContact.builder().credentialsProvider(new StaticApiKeyCredentialProvider("")).build();
-      fcTest.close();
-    } catch (FullContactException e) {
-      Assert.assertEquals("API Key can't be Empty", e.getMessage());
-    }
+  public void emptyStaticKeyTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("API Key can't be Empty");
+    FullContact fcTest =
+        FullContact.builder().credentialsProvider(new StaticApiKeyCredentialProvider("")).build();
+    fcTest.close();
   }
 
   @Test
-  public void nullStaticKeyTest() {
-    try {
-
-      FullContact fcTest =
-          FullContact.builder()
-              .credentialsProvider(new StaticApiKeyCredentialProvider(null))
-              .build();
-      fcTest.close();
-
-    } catch (FullContactException e) {
-      Assert.assertEquals("API Key can't be Empty", e.getMessage());
-    }
+  public void nullStaticKeyTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("API Key can't be Empty");
+    FullContact fcTest =
+        FullContact.builder().credentialsProvider(new StaticApiKeyCredentialProvider(null)).build();
+    fcTest.close();
   }
 
   @Test
@@ -68,5 +58,6 @@ public class FullContactClientTest {
             .connectTimeoutMillis(2000)
             .retryHandler(new CustomRetryHandler())
             .build();
+    fcTest.close();
   }
 }

--- a/java8/src/test/java/com/fullcontact/apilib/enrich/PersonRequestTest.java
+++ b/java8/src/test/java/com/fullcontact/apilib/enrich/PersonRequestTest.java
@@ -8,7 +8,9 @@ import com.fullcontact.apilib.models.Request.PersonRequest;
 import com.fullcontact.apilib.models.enums.Confidence;
 import com.google.gson.Gson;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -18,6 +20,7 @@ import java.util.List;
 
 public class PersonRequestTest {
   private static final Gson gson = new Gson();
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   @Test
   public void personRequestBuildAndSerializeTest() throws FullContactException, IOException {
@@ -73,221 +76,263 @@ public class PersonRequestTest {
   }
 
   @Test
-  public void nameWithLocationAsNullTest() {
-    try {
-      PersonRequest personRequest =
-          FullContact.buildPersonRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .build();
-      personRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
-          fce.getMessage());
-    }
-  }
-
-  @Test
-  public void locationWithNameAsNull() {
-    try {
-      PersonRequest personRequest =
-          FullContact.buildPersonRequest()
-              .location(
-                  Location.builder()
-                      .addressLine1("123/23")
-                      .addressLine2("Some Street")
-                      .city("Denver")
-                      .region("Denver")
-                      .regionCode("123123")
-                      .postalCode("23124")
-                      .build())
-              .build();
-      personRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
-          fce.getMessage());
-    }
-  }
-
-  @Test
-  public void locationWithNoAddressLine1Test() {
-    try {
-      PersonRequest personRequest =
-          FullContact.buildPersonRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(
-                  Location.builder()
-                      .addressLine2("Some Street")
-                      .city("Denver")
-                      .region("Denver")
-                      .regionCode("123123")
-                      .postalCode("23124")
-                      .build())
-              .build();
-      personRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
-  }
-
-  @Test
-  public void locationWithOnlyAddressLine1Test() {
-    try {
-      PersonRequest personRequest =
-          FullContact.buildPersonRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(Location.builder().addressLine1("123/23").build())
-              .build();
-      personRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
-  }
-
-  @Test
-  public void locationWithAddressLine1AndCityTest() {
-    try {
-      PersonRequest personRequest =
-          FullContact.buildPersonRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(Location.builder().addressLine1("123/23").city("Denver").build())
-              .build();
-      personRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
-  }
-
-  @Test
-  public void locationWithAddressLine1AndRegionTest() {
-    try {
-      PersonRequest personRequest =
-          FullContact.buildPersonRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(Location.builder().addressLine1("123/23").region("Denver").build())
-              .build();
-      personRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
-  }
-
-  @Test
-  public void validLocation1Test() throws FullContactException {
+  public void nameWithLocationAsNullTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values");
     PersonRequest personRequest =
         FullContact.buildPersonRequest()
             .name(PersonName.builder().full("Marian C Reed").build())
-            .location(Location.builder().addressLine1("123/23").postalCode("23124").build())
             .build();
+    personRequest.validate();
   }
 
   @Test
-  public void validLocation2Test() throws FullContactException {
+  public void locationWithNameAsNull() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values");
     PersonRequest personRequest =
         FullContact.buildPersonRequest()
-            .name(PersonName.builder().full("Marian C Reed").build())
             .location(
                 Location.builder()
                     .addressLine1("123/23")
                     .addressLine2("Some Street")
                     .city("Denver")
                     .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
                     .build())
             .build();
+    personRequest.validate();
   }
 
   @Test
-  public void validLocation3Test() throws FullContactException {
-
+  public void locationWithNoAddressLine1Test() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
     PersonRequest personRequest =
         FullContact.buildPersonRequest()
             .name(PersonName.builder().full("Marian C Reed").build())
             .location(
                 Location.builder()
-                    .addressLine1("123/23")
+                    .addressLine2("Some Street")
                     .city("Denver")
+                    .region("Denver")
                     .regionCode("123123")
+                    .postalCode("23124")
                     .build())
             .build();
+    personRequest.validate();
+  }
+
+  @Test
+  public void locationWithOnlyAddressLine1Test() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").build())
+            .build();
+    personRequest.validate();
+  }
+
+  @Test
+  public void locationWithAddressLine1AndCityTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").city("Denver").build())
+            .build();
+    personRequest.validate();
+  }
+
+  @Test
+  public void locationWithAddressLine1AndRegionTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").region("Denver").build())
+            .build();
+    personRequest.validate();
+  }
+
+  @Test
+  public void validLocation1Test() throws FullContactException {
+    FullContact.buildPersonRequest()
+        .name(PersonName.builder().full("Marian C Reed").build())
+        .location(Location.builder().addressLine1("123/23").postalCode("23124").build())
+        .build()
+        .validate();
+  }
+
+  @Test
+  public void validLocation2Test() throws FullContactException {
+    FullContact.buildPersonRequest()
+        .name(PersonName.builder().full("Marian C Reed").build())
+        .location(
+            Location.builder()
+                .addressLine1("123/23")
+                .addressLine2("Some Street")
+                .city("Denver")
+                .region("Denver")
+                .build())
+        .build()
+        .validate();
+  }
+
+  @Test
+  public void validLocation3Test() throws FullContactException {
+    FullContact.buildPersonRequest()
+        .name(PersonName.builder().full("Marian C Reed").build())
+        .location(
+            Location.builder().addressLine1("123/23").city("Denver").regionCode("123123").build())
+        .build()
+        .validate();
   }
 
   @Test
   public void validNameTest() throws FullContactException {
-    PersonRequest personRequest =
-        FullContact.buildPersonRequest()
-            .name(PersonName.builder().given("Marian").family("Reed").build())
-            .location(Location.builder().addressLine1("123/23").postalCode("23124").build())
-            .build();
+    FullContact.buildPersonRequest()
+        .name(PersonName.builder().given("Marian").family("Reed").build())
+        .location(Location.builder().addressLine1("123/23").postalCode("23124").build())
+        .build()
+        .validate();
   }
 
   @Test
   public void validProfileBuilder1Test() throws FullContactException {
-    PersonRequest personRequest =
-        FullContact.buildPersonRequest()
-            .profile(Profile.builder().url("https://twitter.com/mcreedy").build())
-            .build();
+    FullContact.buildPersonRequest()
+        .profile(Profile.builder().url("https://twitter.com/mcreedy").build())
+        .build()
+        .validate();
   }
 
   @Test
   public void validProfileBuilder2Test() throws FullContactException {
-    Profile profile = Profile.builder().service("twitter").url("mcreedy").build();
+    Profile.builder().service("twitter").url("mcreedy").build();
   }
 
   @Test
   public void validProfileBuilder3Test() throws FullContactException {
-    Profile profile = Profile.builder().service("twitter").username("mcreedy").build();
+    Profile.builder().service("twitter").username("mcreedy").build();
   }
 
   @Test
-  public void profileWithUrlAndUserid() {
-    try {
-      Profile profile =
-          Profile.builder().url("https://twitter.com/mcreedy").userid("mcreedy").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Specifying username or userid together with url is not allowed", fce.getMessage());
-    }
+  public void profileWithUrlAndUserid() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Specifying username or userid together with url is not allowed");
+    Profile profile =
+        Profile.builder().url("https://twitter.com/mcreedy").userid("mcreedy").build();
   }
 
   @Test
-  public void profileWithUrlAndUsername() {
-    try {
-      Profile profile =
-          Profile.builder().url("https://twitter.com/mcreedy").username("mcreedy").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Specifying username or userid together with url is not allowed", fce.getMessage());
-    }
+  public void profileWithUrlAndUsername() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Specifying username or userid together with url is not allowed");
+    Profile.builder().url("https://twitter.com/mcreedy").username("mcreedy").build();
   }
 
   @Test
-  public void profileWithOnlyService() {
-    try {
-      Profile profile = Profile.builder().service("twitter").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Either url or service plus username or userid must be set on every profiles entry.",
-          fce.getMessage());
-    }
+  public void profileWithOnlyService() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Either url or service plus username or userid must be set on every profiles entry.");
+    Profile.builder().service("twitter").build();
   }
 
   @Test
-  public void profileWithServiceAndUseridAndUsername() {
-    try {
-      Profile profile =
-          Profile.builder().service("twitter").userid("mcreedy").username("mcreedy").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Specifying userid together with username is not allowed", fce.getMessage());
-    }
+  public void profileWithServiceAndUseridAndUsername() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Specifying userid together with username is not allowed");
+    Profile.builder().service("twitter").userid("mcreedy").username("mcreedy").build();
+  }
+
+  @Test
+  public void nameWithLocationAsNullWithQueryableTest() throws FullContactException {
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .email("test@fullcontact.com")
+            .build();
+    personRequest.validate();
+  }
+
+  @Test
+  public void locationWithNameAsNullWithQueryableTest() throws FullContactException {
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .location(
+                Location.builder()
+                    .addressLine1("123/23")
+                    .addressLine2("Some Street")
+                    .city("Denver")
+                    .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
+                    .build())
+            .phone("1234567")
+            .build();
+    personRequest.validate();
+  }
+
+  @Test
+  public void locationWithNoAddressLine1WithQueryableTest() throws FullContactException {
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(
+                Location.builder()
+                    .addressLine2("Some Street")
+                    .city("Denver")
+                    .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
+                    .build())
+            .recordId("r1")
+            .build();
+    personRequest.validate();
+  }
+
+  @Test
+  public void locationWithOnlyAddressLine1WithQueryableTest() throws FullContactException {
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").build())
+            .profile(Profile.builder().url("http://linkedin/test").build())
+            .build();
+    personRequest.validate();
+  }
+
+  @Test
+  public void locationWithAddressLine1AndCityWithQueryableTest() throws FullContactException {
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").city("Denver").build())
+            .personId("test")
+            .build();
+    personRequest.validate();
+  }
+
+  @Test
+  public void locationWithAddressLine1AndRegionWithQueryableTest() throws FullContactException {
+    PersonRequest personRequest =
+        FullContact.buildPersonRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").region("Denver").build())
+            .maid("1234-sfnos-3432-sdjnwoi")
+            .build();
+    personRequest.validate();
   }
 }

--- a/java8/src/test/java/com/fullcontact/apilib/enrich/PersonRequestTest.java
+++ b/java8/src/test/java/com/fullcontact/apilib/enrich/PersonRequestTest.java
@@ -60,7 +60,8 @@ public class PersonRequestTest {
       while ((line = br.readLine()) != null) {
         sb.append(line.trim());
       }
-      Assert.assertEquals(sb.toString(), gson.toJson(personRequest));
+      PersonRequest expectedRequest = gson.fromJson(sb.toString(), PersonRequest.class);
+      Assert.assertEquals(expectedRequest, personRequest);
     }
   }
 
@@ -68,6 +69,7 @@ public class PersonRequestTest {
   public void requestWithoutNameAndLocation() throws FullContactException {
     PersonRequest personRequest =
         FullContact.buildPersonRequest().email("marianrd97@outlook.com").build();
+    personRequest.validate();
   }
 
   @Test
@@ -77,6 +79,7 @@ public class PersonRequestTest {
           FullContact.buildPersonRequest()
               .name(PersonName.builder().full("Marian C Reed").build())
               .build();
+      personRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
@@ -99,6 +102,7 @@ public class PersonRequestTest {
                       .postalCode("23124")
                       .build())
               .build();
+      personRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
@@ -121,6 +125,7 @@ public class PersonRequestTest {
                       .postalCode("23124")
                       .build())
               .build();
+      personRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
@@ -136,6 +141,7 @@ public class PersonRequestTest {
               .name(PersonName.builder().full("Marian C Reed").build())
               .location(Location.builder().addressLine1("123/23").build())
               .build();
+      personRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
@@ -151,6 +157,7 @@ public class PersonRequestTest {
               .name(PersonName.builder().full("Marian C Reed").build())
               .location(Location.builder().addressLine1("123/23").city("Denver").build())
               .build();
+      personRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
@@ -166,6 +173,7 @@ public class PersonRequestTest {
               .name(PersonName.builder().full("Marian C Reed").build())
               .location(Location.builder().addressLine1("123/23").region("Denver").build())
               .build();
+      personRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",

--- a/java8/src/test/java/com/fullcontact/apilib/enrich/ResolveRequestBuildTest.java
+++ b/java8/src/test/java/com/fullcontact/apilib/enrich/ResolveRequestBuildTest.java
@@ -53,7 +53,8 @@ public class ResolveRequestBuildTest {
       while ((line = br.readLine()) != null) {
         sb.append(line.trim());
       }
-      Assert.assertEquals(sb.toString(), gson.toJson(resolveRequest));
+      ResolveRequest expectedRequest = gson.fromJson(sb.toString(), ResolveRequest.class);
+      Assert.assertEquals(expectedRequest, resolveRequest);
     }
   }
 
@@ -61,6 +62,7 @@ public class ResolveRequestBuildTest {
   public void requestWithoutNameAndLocation() throws FullContactException {
     ResolveRequest resolveRequest =
         FullContact.buildResolveRequest().email("marianrd97@outlook.com").build();
+    resolveRequest.validate();
   }
 
   @Test
@@ -70,6 +72,7 @@ public class ResolveRequestBuildTest {
           FullContact.buildResolveRequest()
               .name(PersonName.builder().full("Marian C Reed").build())
               .build();
+      resolveRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
@@ -92,6 +95,7 @@ public class ResolveRequestBuildTest {
                       .postalCode("23124")
                       .build())
               .build();
+      resolveRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
@@ -114,6 +118,7 @@ public class ResolveRequestBuildTest {
                       .postalCode("23124")
                       .build())
               .build();
+      resolveRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
@@ -129,6 +134,7 @@ public class ResolveRequestBuildTest {
               .name(PersonName.builder().full("Marian C Reed").build())
               .location(Location.builder().addressLine1("123/23").build())
               .build();
+      resolveRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
@@ -144,6 +150,7 @@ public class ResolveRequestBuildTest {
               .name(PersonName.builder().full("Marian C Reed").build())
               .location(Location.builder().addressLine1("123/23").city("Denver").build())
               .build();
+      resolveRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
@@ -159,6 +166,7 @@ public class ResolveRequestBuildTest {
               .name(PersonName.builder().full("Marian C Reed").build())
               .location(Location.builder().addressLine1("123/23").region("Denver").build())
               .build();
+      resolveRequest.validate();
     } catch (FullContactException fce) {
       Assert.assertEquals(
           "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",

--- a/java8/src/test/java/com/fullcontact/apilib/enrich/ResolveRequestBuildTest.java
+++ b/java8/src/test/java/com/fullcontact/apilib/enrich/ResolveRequestBuildTest.java
@@ -8,7 +8,9 @@ import com.fullcontact.apilib.models.Request.ResolveRequest;
 import com.fullcontact.apilib.models.Tag;
 import com.google.gson.Gson;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -18,6 +20,7 @@ import java.util.List;
 
 public class ResolveRequestBuildTest {
   private static final Gson gson = new Gson();
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   @Test
   public void resolveRequestBuildAndSerializeTest() throws FullContactException, IOException {
@@ -66,112 +69,94 @@ public class ResolveRequestBuildTest {
   }
 
   @Test
-  public void nameWithLocationAsNullTest() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .build();
-      resolveRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
-          fce.getMessage());
-    }
+  public void nameWithLocationAsNullTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .build();
+    resolveRequest.validate();
   }
 
   @Test
-  public void locationWithNameAsNull() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest()
-              .location(
-                  Location.builder()
-                      .addressLine1("123/23")
-                      .addressLine2("Some Street")
-                      .city("Denver")
-                      .region("Denver")
-                      .regionCode("123123")
-                      .postalCode("23124")
-                      .build())
-              .build();
-      resolveRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values",
-          fce.getMessage());
-    }
+  public void locationWithNameAsNull() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "If you want to use 'location' or 'name' as an input, both must be present and they must have non-blank values");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .location(
+                Location.builder()
+                    .addressLine1("123/23")
+                    .addressLine2("Some Street")
+                    .city("Denver")
+                    .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
+                    .build())
+            .build();
+    resolveRequest.validate();
   }
 
   @Test
-  public void locationWithNoAddressLine1Test() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(
-                  Location.builder()
-                      .addressLine2("Some Street")
-                      .city("Denver")
-                      .region("Denver")
-                      .regionCode("123123")
-                      .postalCode("23124")
-                      .build())
-              .build();
-      resolveRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
+  public void locationWithNoAddressLine1Test() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(
+                Location.builder()
+                    .addressLine2("Some Street")
+                    .city("Denver")
+                    .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
+                    .build())
+            .build();
+    resolveRequest.validate();
   }
 
   @Test
-  public void locationWithOnlyAddressLine1Test() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(Location.builder().addressLine1("123/23").build())
-              .build();
-      resolveRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
+  public void locationWithOnlyAddressLine1Test() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").build())
+            .build();
+    resolveRequest.validate();
   }
 
   @Test
-  public void locationWithAddressLine1AndCityTest() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(Location.builder().addressLine1("123/23").city("Denver").build())
-              .build();
-      resolveRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
+  public void locationWithAddressLine1AndCityTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").city("Denver").build())
+            .build();
+    resolveRequest.validate();
   }
 
   @Test
-  public void locationWithAddressLine1AndRegionTest() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest()
-              .name(PersonName.builder().full("Marian C Reed").build())
-              .location(Location.builder().addressLine1("123/23").region("Denver").build())
-              .build();
-      resolveRequest.validate();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)",
-          fce.getMessage());
-    }
+  public void locationWithAddressLine1AndRegionTest() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Location data requires addressLine1 and postalCode or addressLine1, city and regionCode (or region)");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").region("Denver").build())
+            .build();
+    resolveRequest.validate();
   }
 
   @Test
@@ -181,6 +166,7 @@ public class ResolveRequestBuildTest {
             .name(PersonName.builder().full("Marian C Reed").build())
             .location(Location.builder().addressLine1("123/23").postalCode("23124").build())
             .build();
+    resolveRequest.validate();
   }
 
   @Test
@@ -196,6 +182,7 @@ public class ResolveRequestBuildTest {
                     .region("Denver")
                     .build())
             .build();
+    resolveRequest.validate();
   }
 
   @Test
@@ -210,6 +197,7 @@ public class ResolveRequestBuildTest {
                     .regionCode("123123")
                     .build())
             .build();
+    resolveRequest.validate();
   }
 
   @Test
@@ -219,6 +207,7 @@ public class ResolveRequestBuildTest {
             .name(PersonName.builder().given("Marian").family("Reed").build())
             .location(Location.builder().addressLine1("123/23").postalCode("23124").build())
             .build();
+    resolveRequest.validate();
   }
 
   @Test
@@ -227,105 +216,81 @@ public class ResolveRequestBuildTest {
         FullContact.buildResolveRequest()
             .profile(Profile.builder().url("https://twitter.com/mcreedy").build())
             .build();
+    resolveRequest.validate();
   }
 
   @Test
   public void validProfileBuilder2Test() throws FullContactException {
-    Profile profile = Profile.builder().service("twitter").url("mcreedy").build();
+    Profile.builder().service("twitter").url("mcreedy").build();
   }
 
   @Test
   public void validProfileBuilder3Test() throws FullContactException {
-    Profile profile = Profile.builder().service("twitter").username("mcreedy").build();
+    Profile.builder().service("twitter").username("mcreedy").build();
   }
 
   @Test
-  public void profileWithUrlAndUserid() {
-    try {
-      Profile profile =
-          Profile.builder().url("https://twitter.com/mcreedy").userid("mcreedy").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Specifying username or userid together with url is not allowed", fce.getMessage());
-    }
+  public void profileWithUrlAndUserid() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Specifying username or userid together with url is not allowed");
+    Profile.builder().url("https://twitter.com/mcreedy").userid("mcreedy").build();
   }
 
   @Test
-  public void profileWithUrlAndUsername() {
-    try {
-      Profile profile =
-          Profile.builder().url("https://twitter.com/mcreedy").username("mcreedy").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Specifying username or userid together with url is not allowed", fce.getMessage());
-    }
+  public void profileWithUrlAndUsername() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Specifying username or userid together with url is not allowed");
+    Profile.builder().url("https://twitter.com/mcreedy").username("mcreedy").build();
   }
 
   @Test
-  public void profileWithOnlyService() {
-    try {
-      Profile profile = Profile.builder().service("twitter").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Either url or service plus username or userid must be set on every profiles entry.",
-          fce.getMessage());
-    }
+  public void profileWithOnlyService() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Either url or service plus username or userid must be set on every profiles entry.");
+    Profile.builder().service("twitter").build();
   }
 
   @Test
-  public void profileWithServiceAndUseridAndUsername() {
-    try {
-      Profile profile =
-          Profile.builder().service("twitter").userid("mcreedy").userid("mcreedy").build();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Specifying userid together with username is not allowed", fce.getMessage());
-    }
+  public void profileWithServiceAndUseridAndUsername() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Specifying userid together with username is not allowed");
+    Profile.builder().service("twitter").userid("mcreedy").username("mcreedy").build();
   }
 
   @Test
-  public void identityMapRequestWithPersonId() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest().email("test").personId("test").build();
-      resolveRequest.validateForIdentityMap();
-    } catch (FullContactException fce) {
-      Assert.assertEquals("Invalid map request, person id must be empty", fce.getMessage());
-    }
+  public void identityMapRequestWithPersonId() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Invalid map request, person id must be empty");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest().email("test").personId("test").build();
+    resolveRequest.validateForIdentityMap();
   }
 
   @Test
-  public void identityMapRequestWithOnlyRecordId() {
-    try {
-      ResolveRequest resolveRequest = FullContact.buildResolveRequest().recordId("test").build();
-      resolveRequest.validateForIdentityMap();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Invalid map request, Any of Email, Phone, SocialProfile, Name and Location must be present",
-          fce.getMessage());
-    }
+  public void identityMapRequestWithOnlyRecordId() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage(
+        "Invalid map request, Any of Email, Phone, SocialProfile, Name and Location must be present");
+    ResolveRequest resolveRequest = FullContact.buildResolveRequest().recordId("test").build();
+    resolveRequest.validateForIdentityMap();
   }
 
   @Test
-  public void identityResolveRequestWithRecordIdAndPersonId() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest().recordId("test").personId("test").build();
-      resolveRequest.validateForIdentityResolve();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Both record id and person id are populated, please select one", fce.getMessage());
-    }
+  public void identityResolveRequestWithRecordIdAndPersonId() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Both record id and person id are populated, please select one");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest().recordId("test").personId("test").build();
+    resolveRequest.validateForIdentityResolve();
   }
 
   @Test
-  public void identityDeleteRequestWithNoRecordId() {
-    try {
-      ResolveRequest resolveRequest = FullContact.buildResolveRequest().personId("test").build();
-      resolveRequest.validateForIdentityDelete();
-    } catch (FullContactException fce) {
-      Assert.assertEquals("recordId param must be specified", fce.getMessage());
-    }
+  public void identityDeleteRequestWithNoRecordId() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("recordId param must be specified");
+    ResolveRequest resolveRequest = FullContact.buildResolveRequest().personId("test").build();
+    resolveRequest.validateForIdentityDelete();
   }
 
   @Test
@@ -340,18 +305,94 @@ public class ResolveRequestBuildTest {
   }
 
   @Test
-  public void identityMapWithInvalidTags() {
-    try {
-      ResolveRequest resolveRequest =
-          FullContact.buildResolveRequest()
-              .recordId("test")
-              .email("test")
-              .tag(Tag.builder().key("key").build())
-              .build();
-      resolveRequest.validateForIdentityMap();
-    } catch (FullContactException fce) {
-      Assert.assertEquals(
-          "Both Key and Value must be populated for adding a Tag", fce.getMessage());
-    }
+  public void identityMapWithInvalidTags() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Both Key and Value must be populated for adding a Tag");
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .recordId("test")
+            .email("test")
+            .tag(Tag.builder().key("key").build())
+            .build();
+    resolveRequest.validateForIdentityMap();
+  }
+
+  @Test
+  public void nameWithLocationAsNullWithQueryableTest() throws FullContactException {
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .email("test@fullcontact.com")
+            .build();
+    resolveRequest.validate();
+  }
+
+  @Test
+  public void locationWithNameAsNullWithQueryableTest() throws FullContactException {
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .location(
+                Location.builder()
+                    .addressLine1("123/23")
+                    .addressLine2("Some Street")
+                    .city("Denver")
+                    .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
+                    .build())
+            .phone("1234567")
+            .build();
+    resolveRequest.validate();
+  }
+
+  @Test
+  public void locationWithNoAddressLine1WithQueryableTest() throws FullContactException {
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(
+                Location.builder()
+                    .addressLine2("Some Street")
+                    .city("Denver")
+                    .region("Denver")
+                    .regionCode("123123")
+                    .postalCode("23124")
+                    .build())
+            .recordId("r1")
+            .build();
+    resolveRequest.validate();
+  }
+
+  @Test
+  public void locationWithOnlyAddressLine1WithQueryableTest() throws FullContactException {
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").build())
+            .maid("12334-sdnosf-23423-sldfsi")
+            .build();
+    resolveRequest.validate();
+  }
+
+  @Test
+  public void locationWithAddressLine1AndCityWithQueryableTest() throws FullContactException {
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").city("Denver").build())
+            .profile(Profile.builder().url("http://linkedin/test").build())
+            .build();
+    resolveRequest.validate();
+  }
+
+  @Test
+  public void locationWithAddressLine1AndRegionWithQueryableTest() throws FullContactException {
+    ResolveRequest resolveRequest =
+        FullContact.buildResolveRequest()
+            .name(PersonName.builder().full("Marian C Reed").build())
+            .location(Location.builder().addressLine1("123/23").region("Denver").build())
+            .li_nonid("3iruhow1039oijwe")
+            .build();
+    resolveRequest.validate();
   }
 }

--- a/java8/src/test/java/com/fullcontact/apilib/enrich/ResolveResponseTest.java
+++ b/java8/src/test/java/com/fullcontact/apilib/enrich/ResolveResponseTest.java
@@ -87,7 +87,7 @@ public class ResolveResponseTest {
     ResolveRequest resolveRequest =
         FullContact.buildResolveRequest().phone("test").recordId("customer123").build();
 
-    ResolveResponse response = fcTest.identityMap(resolveRequest).get();
+    ResolveResponse response = fcTest.identityDelete(resolveRequest).get();
     Assert.assertTrue(response.isSuccessful());
     Assert.assertEquals(204, response.getStatusCode());
     Assert.assertEquals("OK", response.getMessage());

--- a/java8/src/test/java/com/fullcontact/apilib/enrich/TagsRequestBuildTest.java
+++ b/java8/src/test/java/com/fullcontact/apilib/enrich/TagsRequestBuildTest.java
@@ -34,7 +34,8 @@ public class TagsRequestBuildTest {
       while ((line = br.readLine()) != null) {
         sb.append(line.trim());
       }
-      Assert.assertEquals(sb.toString(), gson.toJson(tagsRequest));
+      TagsRequest expectedRequest = gson.fromJson(sb.toString(), TagsRequest.class);
+      Assert.assertEquals(expectedRequest, tagsRequest);
     }
   }
 

--- a/java8/src/test/java/com/fullcontact/apilib/enrich/TagsRequestBuildTest.java
+++ b/java8/src/test/java/com/fullcontact/apilib/enrich/TagsRequestBuildTest.java
@@ -5,7 +5,9 @@ import com.fullcontact.apilib.models.Request.TagsRequest;
 import com.fullcontact.apilib.models.Tag;
 import com.google.gson.Gson;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -15,6 +17,7 @@ import java.util.List;
 
 public class TagsRequestBuildTest {
   private static final Gson gson = new Gson();
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
 
   @Test
   public void tagsRequestBuildAndSerializeTest() throws FullContactException, IOException {
@@ -40,38 +43,32 @@ public class TagsRequestBuildTest {
   }
 
   @Test
-  public void invalidTagsRequestTest1() {
-    try {
-      TagsRequest tagsRequest =
-          FullContact.buildTagsRequest()
-              .recordId("customer123")
-              .tag(Tag.builder().key("gender").build())
-              .build();
-    } catch (FullContactException e) {
-      Assert.assertEquals("Both Key and Value must be populated for adding a Tag", e.getMessage());
-    }
+  public void invalidTagsRequestTest1() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Both Key and Value must be populated for adding a Tag");
+    TagsRequest tagsRequest =
+        FullContact.buildTagsRequest()
+            .recordId("customer123")
+            .tag(Tag.builder().key("gender").build())
+            .build();
   }
 
   @Test
-  public void invalidTagsRequestTest2() {
-    try {
-      TagsRequest tagsRequest =
-          FullContact.buildTagsRequest()
-              .recordId("customer123")
-              .tag(Tag.builder().value("M").build())
-              .build();
-    } catch (FullContactException e) {
-      Assert.assertEquals("Both Key and Value must be populated for adding a Tag", e.getMessage());
-    }
+  public void invalidTagsRequestTest2() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("Both Key and Value must be populated for adding a Tag");
+    TagsRequest tagsRequest =
+        FullContact.buildTagsRequest()
+            .recordId("customer123")
+            .tag(Tag.builder().value("M").build())
+            .build();
   }
 
   @Test
-  public void invalidTagsRequestTest3() {
-    try {
-      TagsRequest tagsRequest =
-          FullContact.buildTagsRequest().tag(Tag.builder().key("G").value("M").build()).build();
-    } catch (FullContactException e) {
-      Assert.assertEquals("RecordId must be present for creating Tags", e.getMessage());
-    }
+  public void invalidTagsRequestTest3() throws FullContactException {
+    exceptionRule.expect(FullContactException.class);
+    exceptionRule.expectMessage("RecordId must be present for creating Tags");
+    TagsRequest tagsRequest =
+        FullContact.buildTagsRequest().tag(Tag.builder().key("G").value("M").build()).build();
   }
 }


### PR DESCRIPTION
- Separated MultifiedReq from PersonRequest and ResolveRequest
- Common validation logic in MultifieldReq class
- Allow request if any queryable field is present
- Added generic FCResponse, which can be extended by custom response classes
- Merged duplicate/similar code
- Updated tests
- Updated version to 2.3

[ch128325]